### PR TITLE
fix(codex): isolate npm cache and user prefix for CLI updates

### DIFF
--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.15] - 2026-05-31
+
+### Fixed
+- Stopped exposing `/root/.npm` as the runtime npm cache so Codex CLI updates no longer fail with `EACCES` after the terminal drops to the unprivileged `codex` user
+- Gave interactive Codex sessions a persistent user-owned npm cache and global prefix under the persistent Codex user home so `npm install -g @openai/codex@latest` works from the terminal and stays on `PATH`
+- Isolated optional startup-time root CLI updates to a temporary root-owned npm cache instead of reusing the interactive session cache
+
 ## [0.2.14] - 2026-05-24
 
 ### Added

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -11,8 +11,7 @@ ENV \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     TERM=xterm-256color \
-    NODE_OPTIONS=--max-old-space-size=512 \
-    NPM_CONFIG_CACHE=/root/.npm
+    NODE_OPTIONS=--max-old-space-size=512
 
 RUN apk add --no-cache \
     acl \
@@ -54,8 +53,9 @@ RUN case "${BUILD_ARCH}" in \
     echo "${TTYD_SHA256}  /usr/bin/ttyd" | sha256sum -c - && \
     chmod +x /usr/bin/ttyd
 
-RUN npm install -g @openai/codex \
-    && codex --version
+RUN NPM_CONFIG_CACHE=/tmp/npm-cache npm install -g @openai/codex \
+    && codex --version \
+    && rm -rf /tmp/npm-cache
 
 RUN pip3 install --no-cache-dir --break-system-packages hass-mcp
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -183,6 +183,8 @@ npm install -g @openai/codex@latest
 
 The update is bounded by `codex_update_timeout`. If the update fails or times out, the App continues with the image-installed Codex version and logs the failure.
 
+When you run npm global installs from the interactive terminal, the App uses a persistent user-owned npm cache and prefix under the Codex user's home directory. That keeps `npm install -g @openai/codex@latest` writable for the unprivileged runtime user and makes the installed `codex` binary available on `PATH` in later sessions.
+
 ## Home Assistant App Updates
 
 Home Assistant App updates are separate from Codex CLI updates.

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.14"
+version: "0.2.15"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass

--- a/codex/rootfs/usr/local/bin/codex-session
+++ b/codex/rootfs/usr/local/bin/codex-session
@@ -5,19 +5,28 @@ fail_open_shell() {
   local status="${1:-1}"
   local message="${2:-Codex session startup failed.}"
   local fallback_root="${CODEX_STATE_ROOT:-/data/codex-home}/fallback"
+  local fallback_npm_cache="${fallback_root}/.npm"
+  local fallback_npm_prefix="${fallback_root}/.local"
+  local fallback_npm_bin="${fallback_npm_prefix}/bin"
+  local fallback_path="${fallback_npm_bin}:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
   echo "[ERROR] ${message}" >&2
   echo "[ERROR] Startup exit code: ${status}" >&2
   echo "[INFO] Opening an unprivileged diagnostic shell so the Home Assistant terminal stays usable." >&2
 
   if id -u codex >/dev/null 2>&1; then
-    if ! mkdir -p "${fallback_root}/.codex" 2>/dev/null; then
+    if ! mkdir -p "${fallback_root}/.codex" "$fallback_npm_cache" "$fallback_npm_bin" 2>/dev/null; then
       fallback_root="/tmp/codex-fallback"
-      mkdir -p "${fallback_root}/.codex" 2>/dev/null || true
+      fallback_npm_cache="${fallback_root}/.npm"
+      fallback_npm_prefix="${fallback_root}/.local"
+      fallback_npm_bin="${fallback_npm_prefix}/bin"
+      fallback_path="${fallback_npm_bin}:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+      mkdir -p "${fallback_root}/.codex" "$fallback_npm_cache" "$fallback_npm_bin" 2>/dev/null || true
     fi
 
     chown -R 22000:0 "$fallback_root" 2>/dev/null || true
-    chmod 700 "$fallback_root" "${fallback_root}/.codex" 2>/dev/null || true
+    chmod 700 "$fallback_root" "${fallback_root}/.codex" "$fallback_npm_cache" "$fallback_npm_prefix" 2>/dev/null || true
+    chmod 755 "$fallback_npm_bin" 2>/dev/null || true
     cd "$fallback_root" 2>/dev/null || true
 
     exec su-exec 22000:0 env \
@@ -25,6 +34,9 @@ fail_open_shell() {
       "CODEX_HOME=${fallback_root}/.codex" \
       "CODEX_USER_ID=anonymous" \
       "LOGNAME=codex" \
+      "NPM_CONFIG_CACHE=$fallback_npm_cache" \
+      "NPM_CONFIG_PREFIX=$fallback_npm_prefix" \
+      "PATH=$fallback_path" \
       "SHELL=/bin/bash" \
       "TERM=${TERM:-xterm-256color}" \
       "USER=codex" \
@@ -43,6 +55,9 @@ state_root="${CODEX_STATE_ROOT:-/data/codex-home}"
 managed_root="${CODEX_MANAGED_ROOT:-/data/codex-managed}"
 user_root="${state_root}/users/${safe_user}"
 user_codex_home="${user_root}/.codex"
+user_npm_cache="${user_root}/.npm"
+user_npm_prefix="${user_root}/.local"
+user_npm_bin="${user_npm_prefix}/bin"
 work_dir="${CODEX_WORK_DIR:-/homeassistant}"
 session_persist="${CODEX_SESSION_PERSIST:-false}"
 default_model="${CODEX_DEFAULT_MODEL:-}"
@@ -52,8 +67,9 @@ codex_approval_policy="${CODEX_APPROVAL_POLICY:-on-request}"
 session_uid=22000
 system_user="codex"
 session_gid=0
+session_path="${user_npm_bin}:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
-mkdir -p "$user_codex_home" "$user_root" || fail_open_shell "$?" "Unable to create Codex state directories."
+mkdir -p "$user_codex_home" "$user_root" "$user_npm_cache" "$user_npm_bin" || fail_open_shell "$?" "Unable to create Codex state directories."
 
 if ! id -u "$system_user" >/dev/null 2>&1; then
   fail_open_shell 1 "Codex runtime user is missing from the image."
@@ -61,7 +77,8 @@ fi
 
 rm -f "${user_codex_home}/AGENTS.md"
 chown -R "$session_uid:$session_gid" "$user_root" || fail_open_shell "$?" "Unable to set Codex state ownership."
-chmod 700 "$user_root" "$user_codex_home" || fail_open_shell "$?" "Unable to secure Codex state directories."
+chmod 700 "$user_root" "$user_codex_home" "$user_npm_cache" "$user_npm_prefix" || fail_open_shell "$?" "Unable to secure Codex state directories."
+chmod 755 "$user_npm_bin" || fail_open_shell "$?" "Unable to prepare npm bin directory."
 
 if [[ -f "${managed_root}/AGENTS.md" ]]; then
   ln -sfn "${managed_root}/AGENTS.md" "${user_codex_home}/AGENTS.md"
@@ -100,6 +117,9 @@ fi
 export HOME="$user_root"
 export CODEX_HOME="$user_codex_home"
 export CODEX_USER_ID="$safe_user"
+export NPM_CONFIG_CACHE="$user_npm_cache"
+export NPM_CONFIG_PREFIX="$user_npm_prefix"
+export PATH="$session_path"
 export TERM="${TERM:-xterm-256color}"
 
 if ! cd "$work_dir"; then
@@ -118,6 +138,9 @@ session_env=(
   "CODEX_USER_ID=$safe_user"
   "CODEX_WORK_DIR=$work_dir"
   "LOGNAME=$system_user"
+  "NPM_CONFIG_CACHE=$user_npm_cache"
+  "NPM_CONFIG_PREFIX=$user_npm_prefix"
+  "PATH=$session_path"
   "SHELL=/bin/bash"
   "TERM=$TERM"
   "TMUX_TMPDIR=$user_root"

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -74,14 +74,18 @@ unset SUPERVISOR_TOKEN
 
 if [[ "$auto_update_codex" == "true" ]]; then
   update_log="/tmp/codex/codex-update.log"
+  root_npm_cache="/tmp/codex/npm-root-cache"
+  mkdir -p "$root_npm_cache"
+  chmod 700 "$root_npm_cache"
   echo "[INFO] Updating Codex CLI with npm install -g @openai/codex@latest (timeout ${codex_update_timeout}s)"
-  if timeout "$codex_update_timeout" npm install -g @openai/codex@latest >"$update_log" 2>&1; then
+  if timeout "$codex_update_timeout" env NPM_CONFIG_CACHE="$root_npm_cache" npm install -g @openai/codex@latest >"$update_log" 2>&1; then
     echo "[INFO] Codex CLI update completed: $(codex --version 2>/dev/null || echo unknown)"
   else
     update_status=$?
     echo "[WARN] Codex CLI update failed or timed out with exit code ${update_status}; continuing with installed version"
     tail -n 10 "$update_log" 2>/dev/null | sed 's/^/[WARN] update log: /' || true
   fi
+  rm -rf "$root_npm_cache"
 else
   echo "[INFO] auto_update_codex disabled - using image-installed Codex CLI: $(codex --version 2>/dev/null || echo unknown)"
 fi


### PR DESCRIPTION
## Summary
- stop exposing `/root/.npm` as the runtime npm cache
- give the unprivileged Codex session its own persistent npm cache, prefix, and PATH
- isolate startup-time root Codex updates to a temporary root-owned npm cache

## Verification
- `bash -n codex/rootfs/usr/local/bin/codex-start`
- `bash -n codex/rootfs/usr/local/bin/codex-session`
- `python codex/rootfs/usr/local/bin/codex-merge-config <temp>/config.toml 'gpt-5.4' 'true' 'workspace' 'on-request'`
- local temp-prefix npm install of `@openai/codex@latest` verified the installed `codex` binary runs

## Notes
- `bash -n codex/rootfs/usr/local/bin/codex-shell` false-fails in the Windows clone because the untouched file checked out with CRLF locally; the same file passed earlier from the extracted workspace.