### PR TITLE
feat: upgrade Home Assistant Codex App for 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,21 @@ On first launch, Codex prompts you to sign in. The Codex CLI supports ChatGPT si
 
 ## Defaults
 
-- Model: `gpt-5.4`
-- Access: `workspace`
-- Approval policy: `on-request`
+- Model: `gpt-5.6-sol`
+- Access: `full_access`
+- Approval policy: `never`
 - Session persistence: off for a cleaner first sign-in
 - MCP: on
-- Auto-update Codex CLI: off
+- Auto-update Codex CLI: on
+- Runtime user: `root`
 
-Use `full_access` only when you want Codex to run with broad local access inside the App container.
-Use `codex_approval_policy: never` only when you want autonomous execution without per-action approval prompts.
+The App provisions `sol`, `terra`, and `luna` profile files. Launch one with
+`codex --profile sol`, `codex --profile terra`, or `codex --profile luna`.
+They use `xhigh`, `high`, and `medium` reasoning effort respectively.
+
+`full_access`, `never`, and `run_as_root` give Codex autonomous root access
+inside the App container. Use only on a trusted Home Assistant installation.
+
 
 ## Updates
 

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.18] - 2026-07-11
+
+### Fixed
+- Removed the unsupported Remote Control option: Home Assistant containers use the npm Codex install and cannot complete ChatGPT Desktop device pairing
+
+## [0.2.17] - 2026-07-11
+
+### Changed
+- Upgraded the managed default model to `gpt-5.6-sol` and enabled bounded startup CLI updates
+- Added managed `sol`, `terra`, and `luna` profile files with `xhigh`, `high`, and `medium` reasoning effort
+- Made autonomous full-access root sessions the default for trusted installations
+- Added selectable Web App and Codex Remote Control connection modes
+
 All notable changes to this project will be documented in this file.
 
 ## [0.2.15] - 2026-05-31

--- a/codex/README.md
+++ b/codex/README.md
@@ -74,15 +74,18 @@ When Codex or a prompt mentions `/config`, treat it as `/homeassistant` in this 
 | `terminal_theme` | `dark` | Chooses the terminal color theme |
 | `working_directory` | `/homeassistant` | Sets the starting folder |
 | `session_persistence` | `false` | Reattaches terminal sessions through tmux when enabled |
-| `default_model` | `gpt-5.4` | Writes the managed startup model for Codex |
-| `codex_permissions` | `workspace` | Selects Codex local sandbox behavior |
-| `codex_approval_policy` | `on-request` | Selects when Codex asks before running actions |
-| `auto_update_codex` | `false` | Optionally updates Codex CLI at startup |
+| `default_model` | `gpt-5.6-sol` | Writes the managed startup model for Codex |
+| `codex_permissions` | `full_access` | Selects Codex local sandbox behavior |
+| `codex_approval_policy` | `never` | Selects when Codex asks before running actions |
+| `auto_update_codex` | `true` | Optionally updates Codex CLI at startup |
 | `codex_update_timeout` | `300` | Maximum seconds for the optional startup update |
+| `run_as_root` | `true` | Runs Codex sessions as root inside the trusted App container |
 
 ## Models
 
-The App starts with `gpt-5.4` because it is a practical default for Home Assistant work. This is only a default, not a lock.
+The App starts with `gpt-5.6-sol` because it is the current managed default. This is only a default, not a lock.
+It also writes selectable `sol`, `terra`, and `luna` profiles with `xhigh`,
+`high`, and `medium` reasoning effort; use `codex --profile <name>`.
 
 Change models in either place:
 

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.18"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass
@@ -32,11 +32,12 @@ options:
   terminal_theme: dark
   working_directory: /homeassistant
   session_persistence: false
-  default_model: "gpt-5.4"
-  codex_permissions: workspace
-  codex_approval_policy: on-request
-  auto_update_codex: false
+  default_model: "gpt-5.6-sol"
+  codex_permissions: full_access
+  codex_approval_policy: never
+  auto_update_codex: true
   codex_update_timeout: 300
+  run_as_root: true
 schema:
   enable_mcp: bool
   terminal_font_size: int(10,24)
@@ -48,5 +49,6 @@ schema:
   codex_approval_policy: list(on-request|never|untrusted)
   auto_update_codex: bool
   codex_update_timeout: int(30,300)
+  run_as_root: bool
 environment:
   TERM: xterm-256color

--- a/codex/rootfs/usr/local/bin/codex-merge-config
+++ b/codex/rootfs/usr/local/bin/codex-merge-config
@@ -135,6 +135,32 @@ def repair_incompatible_codex_values(config):
     return repaired
 
 
+ROLE_PROFILES = {
+    "sol": "xhigh",
+    "terra": "high",
+    "luna": "medium",
+}
+
+
+def write_role_profiles(config_dir, model, sandbox_mode, approval_policy):
+    """Write selectable Codex profile layers beside the user config."""
+    for profile, reasoning_effort in ROLE_PROFILES.items():
+        profile_path = config_dir / f"profile-{profile}.config.toml"
+        profile_config = {
+            "model": model,
+            "model_reasoning_effort": reasoning_effort,
+            "sandbox_mode": sandbox_mode,
+            "approval_policy": approval_policy,
+        }
+        lines = [
+            "# Managed by the Home Assistant Codex App.",
+            f"# Launch with: codex --profile {profile}",
+            "",
+        ]
+        emit_table(lines, [], profile_config)
+        profile_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
 def main():
     if len(sys.argv) not in (4, 5, 6):
         print(
@@ -254,6 +280,13 @@ def main():
         config.pop("mcp_servers", None)
     if not metadata:
         config.pop("__homeassistant_app", None)
+
+    write_role_profiles(
+        config_path.parent,
+        default_model or "gpt-5.6-sol",
+        managed_sandbox_mode or "danger-full-access",
+        managed_approval_policy or "never",
+    )
 
     lines = [
         "# Codex user configuration",

--- a/codex/rootfs/usr/local/bin/codex-session
+++ b/codex/rootfs/usr/local/bin/codex-session
@@ -64,10 +64,16 @@ default_model="${CODEX_DEFAULT_MODEL:-}"
 enable_mcp="${CODEX_ENABLE_MCP:-true}"
 codex_permissions="${CODEX_PERMISSIONS:-workspace}"
 codex_approval_policy="${CODEX_APPROVAL_POLICY:-on-request}"
+run_as_root="${CODEX_RUN_AS_ROOT:-false}"
 session_uid=22000
 system_user="codex"
 session_gid=0
 session_path="${user_npm_bin}:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+
+if [[ "$run_as_root" == "true" ]]; then
+  session_uid=0
+  system_user="root"
+fi
 
 mkdir -p "$user_codex_home" "$user_root" "$user_npm_cache" "$user_npm_bin" || fail_open_shell "$?" "Unable to create Codex state directories."
 
@@ -107,6 +113,7 @@ cleanup_config_lock
 trap - EXIT
 
 chown "$session_uid:$session_gid" "${user_codex_home}/config.toml" 2>/dev/null || true
+chown "$session_uid:$session_gid" "${user_codex_home}"/profile-*.config.toml 2>/dev/null || true
 chown -h "$session_uid:$session_gid" "${user_codex_home}/AGENTS.md" 2>/dev/null || true
 
 if [[ ! -d "$work_dir" ]]; then
@@ -135,6 +142,7 @@ session_env=(
   "CODEX_ENABLE_MCP=$enable_mcp"
   "CODEX_PERMISSIONS=$codex_permissions"
   "CODEX_APPROVAL_POLICY=$codex_approval_policy"
+  "CODEX_RUN_AS_ROOT=$run_as_root"
   "CODEX_USER_ID=$safe_user"
   "CODEX_WORK_DIR=$work_dir"
   "LOGNAME=$system_user"

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -18,6 +18,7 @@ codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.jso
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
 auto_update_codex="$(jq -r '.auto_update_codex // false' /data/options.json)"
 codex_update_timeout="$(jq -r '.codex_update_timeout // 300' /data/options.json)"
+run_as_root="$(jq -r '.run_as_root // false' /data/options.json)"
 case "$codex_update_timeout" in
   *[!0-9]*|'') codex_update_timeout=300 ;;
 esac
@@ -33,6 +34,7 @@ export CODEX_ENABLE_MCP="$enable_mcp"
 export CODEX_DEFAULT_MODEL="$default_model"
 export CODEX_PERMISSIONS="$codex_permissions"
 export CODEX_APPROVAL_POLICY="$codex_approval_policy"
+export CODEX_RUN_AS_ROOT="$run_as_root"
 export CODEX_HA_URL="http://supervisor/core"
 export CODEX_SUPERVISOR_TOKEN_FILE="/tmp/codex/ha-token"
 

--- a/codex/translations/en.yaml
+++ b/codex/translations/en.yaml
@@ -29,7 +29,7 @@ configuration:
   default_model:
     name: Default Model
     description: >-
-      Persistent startup model for Codex. The App starts with gpt-5.4,
+      Persistent startup model for Codex. The App starts with gpt-5.6-sol,
       and users can still switch models during a session with /model.
   codex_permissions:
     name: Codex Access Level
@@ -53,6 +53,11 @@ configuration:
     description: >-
       Maximum seconds to wait for the optional Codex CLI startup update.
       Applies only when auto-update is enabled.
+  run_as_root:
+    name: Run Codex as root
+    description: >-
+      Run terminal sessions as root. This grants full container access and is
+      intended only for trusted Home Assistant installations.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/codex/translations/es.yaml
+++ b/codex/translations/es.yaml
@@ -30,7 +30,7 @@ configuration:
   default_model:
     name: Modelo Predeterminado
     description: >-
-      Modelo persistente de inicio para Codex. La App inicia con gpt-5.4,
+      Modelo persistente de inicio para Codex. La App inicia con gpt-5.6-sol,
       y los usuarios todavía pueden cambiar el modelo durante la sesión con
       /model.
   codex_permissions:
@@ -56,6 +56,11 @@ configuration:
     description: >-
       Segundos máximos para esperar la actualización opcional de Codex CLI al
       iniciar. Solo aplica cuando la actualización automática está habilitada.
+  run_as_root:
+    name: Ejecutar Codex como root
+    description: >-
+      Ejecuta sesiones de terminal como root. Otorga acceso completo al
+      contenedor y debe usarse solo en instalaciones confiables.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/codex/translations/pt-BR.yaml
+++ b/codex/translations/pt-BR.yaml
@@ -30,7 +30,7 @@ configuration:
   default_model:
     name: Modelo Padrão
     description: >-
-      Modelo persistente inicial para o Codex. A App inicia com gpt-5.4,
+      Modelo persistente inicial para o Codex. A App inicia com gpt-5.6-sol,
       e os usuários ainda podem trocar o modelo durante a sessão com /model.
   codex_permissions:
     name: Nível de Acesso do Codex
@@ -56,6 +56,11 @@ configuration:
       Segundos máximos para aguardar a atualização opcional do Codex CLI na
       inicialização. Aplica-se apenas quando a atualização automática está
       habilitada.
+  run_as_root:
+    name: Executar Codex como root
+    description: >-
+      Executa sessões de terminal como root. Concede acesso completo ao
+      contêiner e deve ser usado somente em instalações confiáveis.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/tests/test_codex_56_configuration.py
+++ b/tests/test_codex_56_configuration.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Configuration contract for the Codex 5.6 Home Assistant App."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class Codex56ConfigurationTests(unittest.TestCase):
+    def setUp(self):
+        self.config = yaml.safe_load((ROOT / "codex/config.yaml").read_text())
+        self.start = (ROOT / "codex/rootfs/usr/local/bin/codex-start").read_text()
+        self.session = (ROOT / "codex/rootfs/usr/local/bin/codex-session").read_text()
+        self.dockerfile = (ROOT / "codex/Dockerfile").read_text()
+        self.merge = (ROOT / "codex/rootfs/usr/local/bin/codex-merge-config").read_text()
+
+    def test_56_autonomous_role_defaults_are_provisioned(self):
+        options = self.config["options"]
+        self.assertEqual(options["default_model"], "gpt-5.6-sol")
+        self.assertEqual(options["codex_permissions"], "full_access")
+        self.assertEqual(options["codex_approval_policy"], "never")
+        self.assertTrue(options["auto_update_codex"])
+        self.assertTrue(options["run_as_root"])
+        self.assertIn("run_as_root: bool", self._serialized_config())
+        self.assertIn("CODEX_RUN_AS_ROOT", self.start)
+        self.assertIn("CODEX_RUN_AS_ROOT", self.session)
+        self.assertIn("profile-*.config.toml", self.session)
+
+    def test_remote_control_is_not_advertised_for_the_linux_container(self):
+        self.assertNotIn("codex_connection_mode", self._serialized_config())
+        self.assertNotIn("CODEX_CONNECTION_MODE", self.start)
+        self.assertNotIn("CODEX_CONNECTION_MODE", self.session)
+        self.assertNotIn("remote-control", self.dockerfile)
+        self.assertFalse((ROOT / "codex/rootfs/usr/local/bin/codex-remote-session").exists())
+
+    def test_role_profiles_are_managed_and_selectable(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "config.toml"
+            subprocess.run(
+                [
+                    "python3",
+                    str(ROOT / "codex/rootfs/usr/local/bin/codex-merge-config"),
+                    str(config_path),
+                    "gpt-5.6-sol",
+                    "true",
+                    "full_access",
+                    "never",
+                ],
+                check=True,
+            )
+            for profile, effort in (("sol", "xhigh"), ("terra", "high"), ("luna", "medium")):
+                profile_file = config_path.parent / f"profile-{profile}.config.toml"
+                self.assertTrue(profile_file.exists())
+                self.assertIn('model = "gpt-5.6-sol"', profile_file.read_text())
+                self.assertIn(f'model_reasoning_effort = "{effort}"', profile_file.read_text())
+
+    def _serialized_config(self):
+        return (ROOT / "codex/config.yaml").read_text()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Upgrade the managed Codex default to gpt-5.6-sol.
- Add Sol, Terra, and Luna profiles.
- Add full-access, no-approval, root-session, and startup-update defaults.
- Keep the supported Home Assistant ingress Web App mode; do not advertise unsupported Remote Control from the Linux container.
- Add regression coverage and documentation.

Fixes #2

## Validation

- python3 -m unittest tests/test_codex_56_configuration.py
- bash -n for startup and session scripts
- Python compile, YAML parse, and git diff --check