### PR TITLE
feat(codex): add one-shot CLI update option

### DIFF
--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - 2026-07-14
+## [0.2.16] - 2026-07-14
 
 ### Added
-- Documented the design for requesting a one-shot Codex CLI update from the add-on configuration, including the retry cycle.
+- Added a one-shot `update_codex_cli` option that updates the Codex CLI on the next App start and records when the request has been consumed.
+- Added shared update handling for one-shot and automatic Codex CLI updates, including bounded timeout, temporary npm cache, and failure logging.
+- Documented how to request and retry a manual Codex CLI update from the App configuration.
 
 ## [0.2.15] - 2026-05-31
 

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2026-07-14
+
+### Added
+- Documented the design for requesting a one-shot Codex CLI update from the add-on configuration, including the retry cycle.
+
 ## [0.2.15] - 2026-05-31
 
 ### Fixed

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod +x \
     /usr/local/bin/hass-mcp-wrapper \
     /usr/local/bin/hass-mcp-root-helper \
     /usr/local/bin/codex-merge-config \
+    /usr/local/bin/codex-update \
     /usr/local/bin/codex-shell \
     /usr/local/bin/codex-session \
     /usr/local/bin/codex-start \

--- a/codex/README.md
+++ b/codex/README.md
@@ -78,6 +78,7 @@ When Codex or a prompt mentions `/config`, treat it as `/homeassistant` in this 
 | `codex_permissions` | `workspace` | Selects Codex local sandbox behavior |
 | `codex_approval_policy` | `on-request` | Selects when Codex asks before running actions |
 | `auto_update_codex` | `false` | Optionally updates Codex CLI at startup |
+| `update_codex_cli` | `false` | Requests one Codex CLI update on the next add-on start |
 | `codex_update_timeout` | `300` | Maximum seconds for the optional startup update |
 
 ## Models
@@ -182,6 +183,15 @@ npm install -g @openai/codex@latest
 ```
 
 The update is bounded by `codex_update_timeout`. If the update fails or times out, the App continues with the image-installed Codex version and logs the failure.
+
+To request a single manual update from the add-on configuration page, enable
+`update_codex_cli`, save the options, and restart the Codex App. The App runs
+the same bounded npm update once, logs the installed version or failure, and
+records that the request was consumed. Disable the option after the restart;
+to retry after a failure, save it as disabled first, then enable it again.
+
+`update_codex_cli` is a one-shot request. `auto_update_codex` remains the
+persistent setting for updating Codex at every App start.
 
 When you run npm global installs from the interactive terminal, the App uses a persistent user-owned npm cache and prefix under the Codex user's home directory. That keeps `npm install -g @openai/codex@latest` writable for the unprivileged runtime user and makes the installed `codex` binary available on `PATH` in later sessions.
 

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.16"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass
@@ -36,6 +36,7 @@ options:
   codex_permissions: workspace
   codex_approval_policy: on-request
   auto_update_codex: false
+  update_codex_cli: false
   codex_update_timeout: 300
 schema:
   enable_mcp: bool
@@ -47,6 +48,7 @@ schema:
   codex_permissions: list(workspace|full_access)
   codex_approval_policy: list(on-request|never|untrusted)
   auto_update_codex: bool
+  update_codex_cli: bool
   codex_update_timeout: int(30,300)
 environment:
   TERM: xterm-256color

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -17,6 +17,7 @@ default_model="$(jq -r '.default_model // ""' /data/options.json)"
 codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.json)"
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
 auto_update_codex="$(jq -r '.auto_update_codex // false' /data/options.json)"
+update_codex_cli="$(jq -r '.update_codex_cli // false' /data/options.json)"
 codex_update_timeout="$(jq -r '.codex_update_timeout // 300' /data/options.json)"
 case "$codex_update_timeout" in
   *[!0-9]*|'') codex_update_timeout=300 ;;
@@ -72,22 +73,35 @@ printf '%s' "${SUPERVISOR_TOKEN:-}" > "$CODEX_SUPERVISOR_TOKEN_FILE"
 chmod 600 "$CODEX_SUPERVISOR_TOKEN_FILE"
 unset SUPERVISOR_TOKEN
 
-if [[ "$auto_update_codex" == "true" ]]; then
-  update_log="/tmp/codex/codex-update.log"
-  root_npm_cache="/tmp/codex/npm-root-cache"
-  mkdir -p "$root_npm_cache"
-  chmod 700 "$root_npm_cache"
-  echo "[INFO] Updating Codex CLI with npm install -g @openai/codex@latest (timeout ${codex_update_timeout}s)"
-  if timeout "$codex_update_timeout" env NPM_CONFIG_CACHE="$root_npm_cache" npm install -g @openai/codex@latest >"$update_log" 2>&1; then
-    echo "[INFO] Codex CLI update completed: $(codex --version 2>/dev/null || echo unknown)"
-  else
-    update_status=$?
-    echo "[WARN] Codex CLI update failed or timed out with exit code ${update_status}; continuing with installed version"
-    tail -n 10 "$update_log" 2>/dev/null | sed 's/^/[WARN] update log: /' || true
+update_state_file="$CODEX_MANAGED_ROOT/update_codex_cli.state"
+one_shot_update_attempted=false
+if [[ "$update_codex_cli" == "true" ]]; then
+  previous_update_request="false"
+  if [[ -f "$update_state_file" ]]; then
+    previous_update_request="$(cat "$update_state_file")"
   fi
-  rm -rf "$root_npm_cache"
+
+  if [[ "$previous_update_request" != "true" ]]; then
+    one_shot_update_attempted=true
+    /usr/local/bin/codex-update "$codex_update_timeout" || true
+    state_tmp="${update_state_file}.tmp.$$"
+    printf 'true\n' > "$state_tmp"
+    mv -f "$state_tmp" "$update_state_file"
+  else
+    echo "[INFO] Codex CLI one-shot update already consumed - using installed version"
+  fi
 else
-  echo "[INFO] auto_update_codex disabled - using image-installed Codex CLI: $(codex --version 2>/dev/null || echo unknown)"
+  state_tmp="${update_state_file}.tmp.$$"
+  printf 'false\n' > "$state_tmp"
+  mv -f "$state_tmp" "$update_state_file"
+fi
+
+if [[ "$auto_update_codex" == "true" && "$one_shot_update_attempted" != "true" ]]; then
+  /usr/local/bin/codex-update "$codex_update_timeout" || true
+elif [[ "$auto_update_codex" == "true" ]]; then
+  echo "[INFO] Automatic Codex CLI update satisfied by the pending one-shot update"
+else
+  echo "[INFO] auto_update_codex disabled - using installed Codex CLI: $(codex --version 2>/dev/null || echo unknown)"
 fi
 
 cat > "$CODEX_MANAGED_ROOT/AGENTS.md" <<'EOF'

--- a/codex/rootfs/usr/local/bin/codex-update
+++ b/codex/rootfs/usr/local/bin/codex-update
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -u
+
+timeout_seconds="${1:-300}"
+update_log="/tmp/codex/codex-update.log"
+root_npm_cache="/tmp/codex/npm-root-cache"
+update_lock="/tmp/codex/codex-update.lock"
+
+mkdir -p /tmp/codex "$root_npm_cache"
+chmod 700 /tmp/codex "$root_npm_cache"
+
+if ! mkdir "$update_lock" 2>/dev/null; then
+  echo "[WARN] Another Codex CLI update is already running; skipping this request"
+  exit 1
+fi
+
+cleanup() {
+  rm -rf "$root_npm_cache" "$update_lock"
+}
+trap cleanup EXIT
+
+echo "[INFO] Updating Codex CLI with npm install -g @openai/codex@latest (timeout ${timeout_seconds}s)"
+timeout_status=0
+timeout "$timeout_seconds" env NPM_CONFIG_CACHE="$root_npm_cache" \
+  npm install -g @openai/codex@latest >"$update_log" 2>&1 || timeout_status=$?
+if [[ "$timeout_status" -eq 0 ]]; then
+  echo "[INFO] Codex CLI update completed: $(codex --version 2>/dev/null || echo unknown)"
+  exit 0
+fi
+
+echo "[WARN] Codex CLI update failed or timed out with exit code ${timeout_status}; continuing with installed version"
+tail -n 10 "$update_log" 2>/dev/null | sed 's/^/[WARN] update log: /' || true
+exit "$timeout_status"

--- a/codex/translations/en.yaml
+++ b/codex/translations/en.yaml
@@ -48,11 +48,16 @@ configuration:
     description: >-
       Check for the latest Codex CLI on startup with a bounded npm install.
       Disabled by default so startup remains predictable.
+  update_codex_cli:
+    name: Update Codex CLI now
+    description: >-
+      Run one update of the Codex CLI on the next add-on start. Save this
+      option, restart the add-on, then turn it off after the update request is consumed.
   codex_update_timeout:
     name: Codex Update Timeout
     description: >-
       Maximum seconds to wait for the optional Codex CLI startup update.
-      Applies only when auto-update is enabled.
+      Applies to automatic and one-shot updates.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/codex/translations/es.yaml
+++ b/codex/translations/es.yaml
@@ -51,11 +51,16 @@ configuration:
       Busca la versión más reciente de Codex CLI al iniciar con una instalación
       npm limitada por tiempo. Deshabilitado por defecto para mantener un inicio
       predecible.
+  update_codex_cli:
+    name: Actualizar Codex CLI ahora
+    description: >-
+      Ejecuta una actualización de Codex CLI al iniciar el complemento la próxima vez.
+      Guarda esta opción, reinicia el complemento y desactívala después de consumir la solicitud.
   codex_update_timeout:
     name: Tiempo máximo de actualización
     description: >-
       Segundos máximos para esperar la actualización opcional de Codex CLI al
-      iniciar. Solo aplica cuando la actualización automática está habilitada.
+      iniciar. Se aplica a las actualizaciones automáticas y puntuales.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/codex/translations/pt-BR.yaml
+++ b/codex/translations/pt-BR.yaml
@@ -50,12 +50,16 @@ configuration:
       Procura a versão mais recente do Codex CLI na inicialização com uma
       instalação npm limitada por tempo. Desabilitado por padrão para manter a
       inicialização previsível.
+  update_codex_cli:
+    name: Atualizar o Codex CLI agora
+    description: >-
+      Executa uma atualização do Codex CLI na próxima inicialização do app.
+      Salve esta opção, reinicie o app e desative-a depois que a solicitação for consumida.
   codex_update_timeout:
     name: Tempo limite da atualização
     description: >-
       Segundos máximos para aguardar a atualização opcional do Codex CLI na
-      inicialização. Aplica-se apenas quando a atualização automática está
-      habilitada.
+      inicialização. Aplica-se às atualizações automáticas e únicas.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/docs/superpowers/specs/2026-07-14-codex-cli-manual-update-design.md
+++ b/docs/superpowers/specs/2026-07-14-codex-cli-manual-update-design.md
@@ -1,0 +1,96 @@
+# Codex CLI manual update option
+
+## Goal
+
+Allow a Home Assistant user to request a one-time update of the Codex CLI from
+the add-on configuration page. The update targets only the npm package
+`@openai/codex@latest`; it must not update or rebuild the Home Assistant
+add-on image.
+
+## User-facing behavior
+
+- Add a boolean option named `update_codex_cli`, disabled by default.
+- The option is presented with translated name and description in the existing
+  add-on configuration form.
+- When the user enables the option and saves the configuration, the next
+  add-on start performs the update before launching `ttyd`.
+- The option is treated as a one-shot request. After the request has been
+  consumed, the running container records that it has been processed so a
+  later restart does not repeat the update unless the user enables the option
+  again.
+- The existing `auto_update_codex` option remains available for users who want
+  an update on every start. The two modes are independent; a one-shot request
+  must not change the persistent automatic-update setting.
+
+## Architecture and data flow
+
+1. `codex/config.yaml` declares `update_codex_cli: false` and its boolean
+   schema entry.
+2. The translation files add the field label and help text.
+3. `codex-start` reads the option from `/data/options.json` and checks a
+   persistent marker under `/data/codex-managed`.
+4. If the request is pending, `codex-start` invokes the existing bounded npm
+   update path using the root-owned temporary npm cache, records success or
+   failure in the add-on log, and writes a marker showing that the request was
+   consumed.
+5. The marker is written atomically and is not used to modify
+   `/data/options.json`, since Supervisor owns that file. The managed state
+   records the last observed boolean value. A `true` value triggers an update
+   only when the previous observed value was `false` or no value exists; a
+   `false` value is recorded without updating. This makes the
+   `true -> false -> true` cycle a new request while a restart with `true` is
+   ignored.
+6. Codex startup continues with the newly installed version on success or the
+   pre-existing version on failure.
+
+The implementation should centralize the npm update command and timeout/error
+handling in a small helper so automatic and one-shot updates cannot drift.
+
+## Request de-duplication
+
+Because Supervisor owns `/data/options.json`, the add-on must not attempt to
+rewrite the configuration option after consuming it. The managed state records
+the last observed value as `true` or `false`. A true option whose previous
+state is already `true` is ignored; when the user disables and later re-enables
+the option, the intervening `false` state allows the new update request.
+
+If the add-on is restarted during an update, the request must remain pending
+until the update command has returned. The marker is written only after the
+command finishes, and the command is guarded by a lock to prevent concurrent
+startup paths from running npm twice. A failed or timed-out command is still a
+consumed request; the user can retry by saving `false`, then saving `true`.
+
+## Error handling and security
+
+- Keep the existing 30–300 second timeout bounds.
+- Keep npm output in a temporary log and expose only a short tail in the
+  add-on log on failure.
+- Never pass the Supervisor token to npm.
+- Use a root-owned temporary cache for startup updates and remove it after the
+  command completes.
+- Never prevent `ttyd` from starting solely because the update failed.
+- The update remains limited to the globally installed Codex package; no
+  arbitrary package name comes from user input.
+
+## Documentation
+
+Update `codex/README.md` to explain the one-shot option, the need to save and
+restart the add-on, how to read the update result in the add-on log, and the
+difference from `auto_update_codex`.
+
+## Verification
+
+- Validate YAML syntax for `config.yaml` and all translation files.
+- Exercise the startup update decision logic with the option disabled, a first
+  enabled request, a repeated start with the same request, and a disable/re-
+  enable cycle.
+- Verify that a failed or timed-out npm command still reaches terminal startup.
+- Run shell syntax checks for all changed shell scripts and the repository's
+  available tests/checks.
+- Confirm the existing automatic-update behavior remains unchanged.
+
+## Scope exclusions
+
+- No custom frontend or Home Assistant core modification.
+- No button injection into Home Assistant's native app page.
+- No update of the Home Assistant add-on image itself.


### PR DESCRIPTION
## Summary

- Add a `update_codex_cli` Home Assistant App option for a one-shot Codex CLI update on the next App start.
- Centralize npm update handling with bounded timeout, temporary root cache, locking, and failure logging.
- Preserve the existing persistent `auto_update_codex` behavior without running two updates for the same start.
- Document the workflow and add translations for the configuration option.

## User impact

Users can enable `update_codex_cli` in the Codex App configuration, save the options, restart the App, and then disable the option after the request is consumed. A failed update does not prevent the terminal from starting; users can retry by disabling and re-enabling the option.

## Validation

- Bash syntax checks passed for the changed startup and update scripts.
- YAML parsing passed for `config.yaml` and all translation files.
- `git diff --check` passed.
- Failure-path test confirmed npm errors are propagated and the update lock/cache are cleaned up.

## Notes

This PR updates the Codex CLI only; it does not update the Home Assistant App image itself.
