### PR TITLE
fix(codex): honor disabled bundled MCP

### DIFF
--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.16] - 2026-08-26
+
+### Fixed
+- Preserve an explicit `enable_mcp: false` App option so the bundled Home Assistant MCP server remains disabled
+- Report the effective bundled MCP state clearly during startup
+- Limit routine ttyd and libwebsockets connection logging to warnings and errors
+
 ## [0.2.15] - 2026-05-31
 
 ### Fixed

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.16"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -12,7 +12,7 @@ fi
 theme="$(jq -r '.terminal_theme // "dark"' /data/options.json)"
 session_persist="$(jq -r '.session_persistence // false' /data/options.json)"
 work_dir="$(jq -r '.working_directory // "/homeassistant"' /data/options.json)"
-enable_mcp="$(jq -r '.enable_mcp // true' /data/options.json)"
+enable_mcp="$(jq -r '.enable_mcp' /data/options.json)"
 default_model="$(jq -r '.default_model // ""' /data/options.json)"
 codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.json)"
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
@@ -171,10 +171,10 @@ else
 fi
 if [[ "$enable_mcp" == "true" ]]; then
   CODEX_HOME="$validate_home" codex mcp get homeassistant >/dev/null
-  echo "[INFO] Home Assistant MCP configured for Codex home"
+  echo '[INFO] Bundled MCP server registered: "homeassistant" (voska/hass-mcp)'
 else
   CODEX_HOME="$validate_home" codex mcp list >/dev/null
-  echo "[INFO] Home Assistant MCP disabled"
+  echo '[INFO] Bundled MCP server disabled: "homeassistant"'
 fi
 rm -rf "$validate_home"
 trap - EXIT
@@ -186,6 +186,7 @@ else
 fi
 
 exec ttyd \
+  --debug 3 \
   --port 7681 \
   --writable \
   --ping-interval 30 \

--- a/codex/tests/test_bundled_mcp_option.py
+++ b/codex/tests/test_bundled_mcp_option.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+START_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-start"
+MERGE_CONFIG = CODEX_DIR / "rootfs/usr/local/bin/codex-merge-config"
+
+
+class BundledMcpOptionTests(unittest.TestCase):
+    def test_explicit_false_is_not_replaced_by_default(self):
+        start_text = START_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotIn(".enable_mcp // true", start_text)
+        result = subprocess.run(
+            ["jq", "-r", ".enable_mcp"],
+            input=json.dumps({"enable_mcp": False}),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "false")
+
+    def test_disabling_bundled_mcp_removes_managed_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "config.toml"
+
+            enabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "true", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(enabled.returncode, 0, enabled.stderr)
+            self.assertIn(
+                "homeassistant",
+                tomllib.loads(config_path.read_text(encoding="utf-8"))["mcp_servers"],
+            )
+
+            disabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "false", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(disabled.returncode, 0, disabled.stderr)
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("mcp_servers", config)
+            self.assertNotIn(
+                "managed_homeassistant_mcp",
+                config.get("__homeassistant_app", {}),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve an explicit `enable_mcp: false` instead of replacing it with the default
- remove the managed `homeassistant` server from Codex config when bundled MCP is disabled
- make MCP startup logging clearer and reduce routine ttyd connection noise
- add regression tests for option parsing and managed-config behavior

## Testing

- `python3 -B -m unittest discover -s codex/tests -v`
- `bash -n codex/rootfs/usr/local/bin/codex-start codex/rootfs/usr/local/bin/codex-shell`
- parsed App and repository YAML
- `git diff --check`

This is an independent fix based directly on upstream `main`.
