### PR TITLE
fix(codex): persist CLI startup updates

### DIFF
--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.16] - 2026-08-26
+
+### Fixed
+- Install optional startup-time Codex CLI updates into the persistent unprivileged npm prefix instead of the AppArmor-protected image prefix
+- Allow updated Codex CLI binaries and their Node.js packages to execute under the AppArmor profile
+- Fall back to the image-installed Codex CLI if a persisted update cannot execute
+
 ## [0.2.15] - 2026-05-31
 
 ### Fixed

--- a/codex/README.md
+++ b/codex/README.md
@@ -181,7 +181,11 @@ Enable `auto_update_codex` if you want the App to run this on startup:
 npm install -g @openai/codex@latest
 ```
 
-The update is bounded by `codex_update_timeout`. If the update fails or times out, the App continues with the image-installed Codex version and logs the failure.
+The update is bounded by `codex_update_timeout`. It is installed as the
+unprivileged `codex` user into the persistent npm prefix under the Codex home,
+so a successful update survives App restarts and image upgrades. If the update
+fails, times out, or cannot execute, the App continues with the image-installed
+Codex version and logs the failure.
 
 When you run npm global installs from the interactive terminal, the App uses a persistent user-owned npm cache and prefix under the Codex user's home directory. That keeps `npm install -g @openai/codex@latest` writable for the unprivileged runtime user and makes the installed `codex` binary available on `PATH` in later sessions.
 

--- a/codex/apparmor.txt
+++ b/codex/apparmor.txt
@@ -68,4 +68,8 @@ profile codex flags=(attach_disconnected,mediate_deleted) {
 
   # Node.js modules
   /usr/lib/node_modules/** ixmr,
+
+  # User-installed npm binaries and packages in the persistent Codex home
+  /data/codex-home/users/*/.local/bin/** ixr,
+  /data/codex-home/users/*/.local/lib/node_modules/** ixmr,
 }

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.16"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass

--- a/codex/rootfs/usr/local/bin/codex-shell
+++ b/codex/rootfs/usr/local/bin/codex-shell
@@ -26,12 +26,20 @@ repair_codex_config() {
 }
 
 if command -v codex >/dev/null 2>&1; then
+  codex_command="$(command -v codex)"
   while true; do
     repair_codex_config
-    codex
+    "$codex_command"
     codex_status=$?
     if [[ "$codex_status" -eq 0 ]]; then
       break
+    fi
+
+    if [[ "$codex_status" -eq 126 && "$codex_command" != "/usr/local/bin/codex" && -x /usr/local/bin/codex ]]; then
+      echo
+      echo "[WARN] Updated Codex CLI at ${codex_command} is not executable; falling back to the image-installed version."
+      codex_command="/usr/local/bin/codex"
+      continue
     fi
 
     echo

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -74,20 +74,29 @@ unset SUPERVISOR_TOKEN
 
 if [[ "$auto_update_codex" == "true" ]]; then
   update_log="/tmp/codex/codex-update.log"
-  root_npm_cache="/tmp/codex/npm-root-cache"
-  mkdir -p "$root_npm_cache"
-  chmod 700 "$root_npm_cache"
+  update_user_root="$CODEX_STATE_ROOT/users/anonymous"
+  update_npm_cache="$update_user_root/.npm"
+  update_npm_prefix="$update_user_root/.local"
+  update_npm_bin="$update_npm_prefix/bin"
+  mkdir -p "$update_npm_cache" "$update_npm_bin"
+  chown -R 22000:0 "$update_user_root"
+  chmod 700 "$update_user_root" "$update_npm_cache" "$update_npm_prefix"
+  chmod 755 "$update_npm_bin"
   echo "[INFO] Updating Codex CLI with npm install -g @openai/codex@latest (timeout ${codex_update_timeout}s)"
-  if timeout "$codex_update_timeout" env NPM_CONFIG_CACHE="$root_npm_cache" npm install -g @openai/codex@latest >"$update_log" 2>&1; then
-    echo "[INFO] Codex CLI update completed: $(codex --version 2>/dev/null || echo unknown)"
+  if timeout "$codex_update_timeout" su-exec 22000:0 env \
+    "HOME=$update_user_root" \
+    "NPM_CONFIG_CACHE=$update_npm_cache" \
+    "NPM_CONFIG_PREFIX=$update_npm_prefix" \
+    "PATH=$update_npm_bin:${PATH}" \
+    npm install -g @openai/codex@latest >"$update_log" 2>&1; then
+    echo "[INFO] Codex CLI update completed: $("$update_npm_bin/codex" --version 2>/dev/null || echo unknown)"
   else
     update_status=$?
     echo "[WARN] Codex CLI update failed or timed out with exit code ${update_status}; continuing with installed version"
     tail -n 10 "$update_log" 2>/dev/null | sed 's/^/[WARN] update log: /' || true
   fi
-  rm -rf "$root_npm_cache"
 else
-  echo "[INFO] auto_update_codex disabled - using image-installed Codex CLI: $(codex --version 2>/dev/null || echo unknown)"
+  echo "[INFO] Codex CLI auto-update disabled - using image-installed version: $(codex --version 2>/dev/null || echo unknown)"
 fi
 
 cat > "$CODEX_MANAGED_ROOT/AGENTS.md" <<'EOF'

--- a/codex/tests/test_cli_updates.py
+++ b/codex/tests/test_cli_updates.py
@@ -1,0 +1,38 @@
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+START_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-start"
+SHELL_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-shell"
+APPARMOR_PROFILE = CODEX_DIR / "apparmor.txt"
+
+
+class CliUpdateTests(unittest.TestCase):
+    def test_startup_update_uses_persistent_unprivileged_prefix(self):
+        start_text = START_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('update_user_root="$CODEX_STATE_ROOT/users/anonymous"', start_text)
+        self.assertIn('update_npm_prefix="$update_user_root/.local"', start_text)
+        self.assertIn("su-exec 22000:0 env", start_text)
+        self.assertIn('"NPM_CONFIG_PREFIX=$update_npm_prefix"', start_text)
+        self.assertNotIn("npm-root-cache", start_text)
+
+    def test_persistent_cli_is_executable_under_apparmor(self):
+        profile_text = APPARMOR_PROFILE.read_text(encoding="utf-8")
+
+        self.assertIn("/data/codex-home/users/*/.local/bin/** ixr,", profile_text)
+        self.assertIn(
+            "/data/codex-home/users/*/.local/lib/node_modules/** ixmr,",
+            profile_text,
+        )
+
+    def test_broken_persisted_update_falls_back_to_image_cli(self):
+        shell_text = SHELL_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('codex_status" -eq 126', shell_text)
+        self.assertIn('codex_command="/usr/local/bin/codex"', shell_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- install optional startup updates into the persistent, unprivileged Codex npm prefix
- allow that persistent CLI path through the AppArmor profile
- fall back to the image-provided CLI when a persisted update cannot execute
- document the persistent update behavior and add regression tests

## Testing

- `python3 -B -m unittest discover -s codex/tests -v`
- `bash -n codex/rootfs/usr/local/bin/codex-start codex/rootfs/usr/local/bin/codex-shell`
- parsed App and repository YAML
- `git diff --check`

This is an independent fix based directly on upstream `main`. It deliberately does not add a one-shot update command; that UI/API surface can build on the same persistent-prefix behavior separately.
