### PR TITLE
feat(codex): manage remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Manual install:
 - Direct access to `/homeassistant`, `/share`, and `/media`.
 - Read-only access to `/ssl` and `/backup`.
 - Optional Home Assistant MCP integration for entity lookup and service calls.
+- App options for additional remote MCP servers, bearer tokens, and environment variables.
 - Persistent Codex auth and settings under `/data/codex-home`.
-- Home Assistant options for model default, sandbox access, MCP, terminal theme, and session persistence.
+- Home Assistant options for model default, sandbox access, MCP servers, environment variables, terminal theme, and session persistence.
 
 ## Authentication
 
-Codex authentication happens inside the terminal. Home Assistant does not store your OpenAI API key, ChatGPT session, or Codex access token in App options.
+Codex authentication normally happens inside the terminal, so Home Assistant does not need to store your OpenAI API key, ChatGPT session, or Codex access token in App options. Credentials deliberately added through the optional MCP or environment-variable settings are stored as App options.
 
 On first launch, Codex prompts you to sign in. The Codex CLI supports ChatGPT sign-in for subscription access and API-key sign-in for usage-based access. On headless or remote systems, use the Codex device-code login option if the normal browser callback flow cannot complete.
 

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.17] - 2026-08-26
+
+### Added
+- Add App options for managed remote Streamable HTTP MCP servers and additional Codex environment variables
+- Create a per-server environment variable and configure `bearer_token_env_var` whenever an MCP bearer token is supplied
+
+### Changed
+- Merge managed remote MCP servers into each persistent Codex user configuration and restore a pre-existing same-name server when App management is removed
+- Make configured environment variables available to Codex sessions without writing their values to `config.toml`
+
 ## [0.2.16] - 2026-08-26
 
 ### Fixed

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.16] - 2026-08-26
+
+### Fixed
+- Preserve an explicit `enable_mcp: false` App option so the bundled Home Assistant MCP server remains disabled
+- Report the effective bundled MCP state clearly during startup
+- Limit routine ttyd and libwebsockets connection logging to warnings and errors
+
 ## [0.2.15] - 2026-05-31
 
 ### Fixed

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod +x \
     /usr/local/bin/hass-mcp-wrapper \
     /usr/local/bin/hass-mcp-root-helper \
     /usr/local/bin/codex-merge-config \
+    /usr/local/bin/codex-prepare-mcp \
     /usr/local/bin/codex-shell \
     /usr/local/bin/codex-session \
     /usr/local/bin/codex-start \

--- a/codex/README.md
+++ b/codex/README.md
@@ -13,8 +13,9 @@ It is designed as a Home Assistant-native App, not a copied terminal wrapper. Th
 5. The App generates user-level Codex defaults in `~/.codex/config.toml`.
 6. The App generates `~/.codex/AGENTS.md` with Home Assistant path mapping, log commands, and MCP notes.
 7. If MCP is enabled, Codex gets a managed `homeassistant` MCP server that talks to Home Assistant through `hass-mcp`.
+8. Remote MCP servers and their environment variables configured in the App options are added to every Codex session.
 
-The App keeps OpenAI credentials out of Home Assistant options. Codex signs in using its own CLI authentication flow and stores its own auth state in the persistent Codex home.
+By default, the App keeps OpenAI credentials out of Home Assistant options. Codex signs in using its own CLI authentication flow and stores its own auth state in the persistent Codex home. Credentials deliberately added through `environment_variables` or an MCP `bearer_token` are stored as App options.
 
 ## Install
 
@@ -79,6 +80,8 @@ When Codex or a prompt mentions `/config`, treat it as `/homeassistant` in this 
 | `codex_approval_policy` | `on-request` | Selects when Codex asks before running actions |
 | `auto_update_codex` | `false` | Optionally updates Codex CLI at startup |
 | `codex_update_timeout` | `300` | Maximum seconds for the optional startup update |
+| `mcp_servers` | `[]` | Adds managed remote Streamable HTTP MCP servers to Codex |
+| `environment_variables` | `[]` | Adds environment variables to Codex sessions |
 
 ## Models
 
@@ -130,6 +133,28 @@ When `enable_mcp` is `true`, the App registers a `homeassistant` MCP server in C
 The Supervisor token is not exported into the interactive shell. It is written to a protected runtime file and passed only through the helper path used by `hass-mcp`.
 
 Disable MCP if you only want a terminal and file-editing workflow.
+
+## Additional MCP Servers and Environment Variables
+
+Remote Streamable HTTP MCP servers can be created directly in the App options. Restart the App after changing the list:
+
+```yaml
+mcp_servers:
+  - name: example
+    url: https://mcp.example.com/mcp
+    bearer_token: "your-token"
+environment_variables:
+  - name: EXAMPLE_TENANT
+    value: "home"
+```
+
+`name` must be unique; `homeassistant` is reserved for the built-in integration. URLs must start with `http://` or `https://`.
+
+When `bearer_token` is set, the App automatically creates an environment variable named `CODEX_MCP_<SERVER_NAME>_BEARER_TOKEN` and writes that name as the server's `bearer_token_env_var` in Codex configuration. For example, the server above uses `CODEX_MCP_EXAMPLE_BEARER_TOKEN`. The token value is not written to `config.toml`.
+
+Entries under `environment_variables` are also exported to Codex sessions. Variable names must use letters, digits, and underscores and cannot start with a digit. Their values and bearer tokens are stored in Home Assistant App options and are available to the unprivileged `codex` runtime user, so only add credentials that Codex and its MCP servers are intended to use.
+
+Removing a managed MCP server from the App options removes it from Codex on the next App restart. If an existing user-defined server had the same name before App management began, its previous configuration is restored.
 
 ## Persistence
 
@@ -247,6 +272,8 @@ Version `0.2.13` removes that incompatible UI state automatically and keeps the 
 3. In Codex, check whether the `homeassistant` MCP server appears.
 4. Check the App log for `hass-mcp` or Supervisor token errors.
 
+For an additional MCP server, also confirm that its name is unique, its URL starts with `http://` or `https://`, and the App was restarted after editing `mcp_servers` or `environment_variables`.
+
 ### Project config is ignored
 
 1. Confirm the file is `/homeassistant/.codex/config.toml`.
@@ -263,6 +290,7 @@ Disable `auto_update_codex` unless you specifically need the newest CLI on every
 - [Codex authentication](https://developers.openai.com/codex/auth)
 - [Codex config basics](https://developers.openai.com/codex/config-basic)
 - [Codex config reference](https://developers.openai.com/codex/config-reference)
+- [Codex MCP configuration](https://developers.openai.com/codex/mcp)
 
 ## Support
 

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.16"
+version: "0.2.17"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass
@@ -37,6 +37,8 @@ options:
   codex_approval_policy: on-request
   auto_update_codex: false
   codex_update_timeout: 300
+  mcp_servers: []
+  environment_variables: []
 schema:
   enable_mcp: bool
   terminal_font_size: int(10,24)
@@ -48,5 +50,12 @@ schema:
   codex_approval_policy: list(on-request|never|untrusted)
   auto_update_codex: bool
   codex_update_timeout: int(30,300)
+  mcp_servers:
+    - name: str
+      url: url
+      bearer_token: password?
+  environment_variables:
+    - name: str
+      value: password
 environment:
   TERM: xterm-256color

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.16"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass

--- a/codex/rootfs/usr/local/bin/codex-merge-config
+++ b/codex/rootfs/usr/local/bin/codex-merge-config
@@ -135,10 +135,48 @@ def repair_incompatible_codex_values(config):
     return repaired
 
 
+def load_managed_mcp_servers(path):
+    if path is None:
+        return []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Unable to read managed MCP servers from {path}: {error}") from error
+
+    if not isinstance(loaded, list):
+        raise ValueError("Managed MCP server configuration must be a list")
+
+    servers = []
+    names = set()
+    for index, item in enumerate(loaded):
+        if not isinstance(item, dict):
+            raise ValueError(f"Managed MCP server {index} must be an object")
+        name = item.get("name")
+        url = item.get("url")
+        bearer_token_env_var = item.get("bearer_token_env_var")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Managed MCP server {index} has an invalid name")
+        if name == "homeassistant":
+            raise ValueError("Managed MCP server name 'homeassistant' is reserved")
+        if name in names:
+            raise ValueError(f"Duplicate managed MCP server name: {name}")
+        if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            raise ValueError(f"Managed MCP server {name!r} has an invalid URL")
+        if bearer_token_env_var is not None and (
+            not isinstance(bearer_token_env_var, str) or not bearer_token_env_var
+        ):
+            raise ValueError(f"Managed MCP server {name!r} has an invalid bearer token environment variable")
+        names.add(name)
+        servers.append(item)
+    return servers
+
+
 def main():
-    if len(sys.argv) not in (4, 5, 6):
+    if len(sys.argv) not in (4, 5, 6, 7):
         print(
-            "usage: codex-merge-config <config_path> <default_model> <enable_mcp> [codex_permissions] [codex_approval_policy]",
+            "usage: codex-merge-config <config_path> <default_model> <enable_mcp> "
+            "[codex_permissions] [codex_approval_policy] [managed_mcp_path]",
             file=sys.stderr,
         )
         return 1
@@ -147,7 +185,14 @@ def main():
     default_model = sys.argv[2]
     enable_mcp = sys.argv[3].lower() == "true"
     codex_permissions = sys.argv[4] if len(sys.argv) >= 5 else "workspace"
-    codex_approval_policy = sys.argv[5] if len(sys.argv) == 6 else "on-request"
+    codex_approval_policy = sys.argv[5] if len(sys.argv) >= 6 else "on-request"
+    managed_mcp_path = Path(sys.argv[6]) if len(sys.argv) == 7 and sys.argv[6] else None
+
+    try:
+        managed_mcp_servers = load_managed_mcp_servers(managed_mcp_path)
+    except ValueError as error:
+        print(f"[ERROR] {error}", file=sys.stderr)
+        return 1
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config = load_existing_config(config_path)
@@ -249,6 +294,51 @@ def main():
             metadata["managed_homeassistant_mcp_backup"] = dict(existing_homeassistant)
         mcp_servers.pop("homeassistant", None)
         metadata.pop("managed_homeassistant_mcp", None)
+
+    previous_custom_names = metadata.get("managed_custom_mcp_servers", [])
+    if not isinstance(previous_custom_names, list):
+        previous_custom_names = []
+    previous_custom_names = {
+        name for name in previous_custom_names if isinstance(name, str) and name != "homeassistant"
+    }
+    custom_backups = metadata.get("managed_custom_mcp_backups", {})
+    if not isinstance(custom_backups, dict):
+        custom_backups = {}
+
+    desired_custom_servers = {server["name"]: server for server in managed_mcp_servers}
+    for name in previous_custom_names - desired_custom_servers.keys():
+        mcp_servers.pop(name, None)
+        backup = custom_backups.pop(name, None)
+        if isinstance(backup, dict):
+            mcp_servers[name] = backup
+
+    stdio_only_keys = ("command", "args", "env", "env_vars", "cwd", "experimental_environment")
+    for name, managed_server in desired_custom_servers.items():
+        existing = mcp_servers.get(name, {})
+        if not isinstance(existing, dict):
+            existing = {}
+        if name not in previous_custom_names and existing:
+            custom_backups[name] = dict(existing)
+
+        merged_server = dict(existing)
+        for key in stdio_only_keys:
+            merged_server.pop(key, None)
+        merged_server["url"] = managed_server["url"]
+        bearer_token_env_var = managed_server.get("bearer_token_env_var")
+        if bearer_token_env_var:
+            merged_server["bearer_token_env_var"] = bearer_token_env_var
+        else:
+            merged_server.pop("bearer_token_env_var", None)
+        mcp_servers[name] = merged_server
+
+    if desired_custom_servers:
+        metadata["managed_custom_mcp_servers"] = list(desired_custom_servers)
+    else:
+        metadata.pop("managed_custom_mcp_servers", None)
+    if custom_backups:
+        metadata["managed_custom_mcp_backups"] = custom_backups
+    else:
+        metadata.pop("managed_custom_mcp_backups", None)
 
     if not mcp_servers:
         config.pop("mcp_servers", None)

--- a/codex/rootfs/usr/local/bin/codex-prepare-mcp
+++ b/codex/rootfs/usr/local/bin/codex-prepare-mcp
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def fail(message):
+    print(f"[ERROR] {message}", file=sys.stderr)
+    return 1
+
+
+def write_json_atomic(path, value, mode):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def bearer_env_name(server_name):
+    normalized = re.sub(r"[^A-Za-z0-9_]", "_", server_name).upper()
+    if not normalized or normalized[0].isdigit():
+        normalized = f"_{normalized}"
+    return f"CODEX_MCP_{normalized}_BEARER_TOKEN"
+
+
+def read_string(mapping, key, context, required=False):
+    value = mapping.get(key, "")
+    if not isinstance(value, str):
+        raise ValueError(f"{context}.{key} must be a string")
+    if required and not value.strip():
+        raise ValueError(f"{context}.{key} must not be empty")
+    return value
+
+
+def prepare(options):
+    configured_servers = options.get("mcp_servers", [])
+    configured_environment = options.get("environment_variables", [])
+    if not isinstance(configured_servers, list):
+        raise ValueError("mcp_servers must be a list")
+    if not isinstance(configured_environment, list):
+        raise ValueError("environment_variables must be a list")
+
+    servers = []
+    environment = []
+    server_names = set()
+    environment_names = set()
+
+    for index, item in enumerate(configured_environment):
+        context = f"environment_variables[{index}]"
+        if not isinstance(item, dict):
+            raise ValueError(f"{context} must be an object")
+        name = read_string(item, "name", context, required=True)
+        value = read_string(item, "value", context)
+        if not ENV_NAME_RE.fullmatch(name):
+            raise ValueError(f"{context}.name is not a valid environment variable name: {name!r}")
+        if name in environment_names:
+            raise ValueError(f"duplicate environment variable: {name}")
+        environment_names.add(name)
+        environment.append({"name": name, "value": value})
+
+    for index, item in enumerate(configured_servers):
+        context = f"mcp_servers[{index}]"
+        if not isinstance(item, dict):
+            raise ValueError(f"{context} must be an object")
+        name = read_string(item, "name", context, required=True)
+        url = read_string(item, "url", context, required=True)
+        bearer_token = read_string(item, "bearer_token", context)
+        if name == "homeassistant":
+            raise ValueError("mcp_servers name 'homeassistant' is reserved for the built-in server")
+        if name in server_names:
+            raise ValueError(f"duplicate MCP server name: {name}")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"{context}.url must start with http:// or https://")
+
+        server = {"name": name, "url": url}
+        if bearer_token:
+            env_name = bearer_env_name(name)
+            if env_name in environment_names:
+                raise ValueError(
+                    f"generated bearer-token environment variable conflicts with environment_variables: {env_name}"
+                )
+            environment_names.add(env_name)
+            environment.append({"name": env_name, "value": bearer_token})
+            server["bearer_token_env_var"] = env_name
+
+        server_names.add(name)
+        servers.append(server)
+
+    return servers, environment
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(
+            "usage: codex-prepare-mcp <options_path> <servers_path> <environment_path>",
+            file=sys.stderr,
+        )
+        return 1
+
+    options_path = Path(sys.argv[1])
+    servers_path = Path(sys.argv[2])
+    environment_path = Path(sys.argv[3])
+    try:
+        with options_path.open("r", encoding="utf-8") as handle:
+            options = json.load(handle)
+        if not isinstance(options, dict):
+            return fail("App options must contain a JSON object")
+        servers, environment = prepare(options)
+        write_json_atomic(servers_path, servers, 0o644)
+        write_json_atomic(environment_path, environment, 0o600)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        return fail(f"Unable to prepare custom MCP configuration: {error}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/rootfs/usr/local/bin/codex-session
+++ b/codex/rootfs/usr/local/bin/codex-session
@@ -64,6 +64,8 @@ default_model="${CODEX_DEFAULT_MODEL:-}"
 enable_mcp="${CODEX_ENABLE_MCP:-true}"
 codex_permissions="${CODEX_PERMISSIONS:-workspace}"
 codex_approval_policy="${CODEX_APPROVAL_POLICY:-on-request}"
+managed_mcp_config="${CODEX_MCP_CONFIG:-${managed_root}/mcp-servers.json}"
+managed_mcp_environment="${CODEX_MCP_ENVIRONMENT:-${managed_root}/mcp-environment.json}"
 session_uid=22000
 system_user="codex"
 session_gid=0
@@ -95,7 +97,13 @@ cleanup_config_lock() {
 
 trap cleanup_config_lock EXIT
 
-/usr/local/bin/codex-merge-config "${user_codex_home}/config.toml" "$default_model" "$enable_mcp" "$codex_permissions" "$codex_approval_policy"
+/usr/local/bin/codex-merge-config \
+  "${user_codex_home}/config.toml" \
+  "$default_model" \
+  "$enable_mcp" \
+  "$codex_permissions" \
+  "$codex_approval_policy" \
+  "$managed_mcp_config"
 merge_status=$?
 if [[ "$merge_status" -ne 0 ]]; then
   cleanup_config_lock
@@ -135,6 +143,8 @@ session_env=(
   "CODEX_ENABLE_MCP=$enable_mcp"
   "CODEX_PERMISSIONS=$codex_permissions"
   "CODEX_APPROVAL_POLICY=$codex_approval_policy"
+  "CODEX_MCP_CONFIG=$managed_mcp_config"
+  "CODEX_MCP_ENVIRONMENT=$managed_mcp_environment"
   "CODEX_USER_ID=$safe_user"
   "CODEX_WORK_DIR=$work_dir"
   "LOGNAME=$system_user"
@@ -146,6 +156,14 @@ session_env=(
   "TMUX_TMPDIR=$user_root"
   "USER=$system_user"
 )
+
+if [[ -r "$managed_mcp_environment" ]]; then
+  while IFS= read -r -d '' env_name && IFS= read -r -d '' env_value; do
+    if [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      session_env+=("$env_name=$env_value")
+    fi
+  done < <(jq -j '.[] | .name, "\u0000", .value, "\u0000"' "$managed_mcp_environment")
+fi
 
 if [[ "$session_persist" == "true" ]]; then
   tmux_socket="${user_root}/tmux.sock"

--- a/codex/rootfs/usr/local/bin/codex-shell
+++ b/codex/rootfs/usr/local/bin/codex-shell
@@ -19,7 +19,8 @@ repair_codex_config() {
       "${CODEX_DEFAULT_MODEL:-}" \
       "${CODEX_ENABLE_MCP:-true}" \
       "${CODEX_PERMISSIONS:-workspace}" \
-      "${CODEX_APPROVAL_POLICY:-on-request}" || {
+      "${CODEX_APPROVAL_POLICY:-on-request}" \
+      "${CODEX_MCP_CONFIG:-/data/codex-managed/mcp-servers.json}" || {
         echo "[WARN] Unable to repair Codex config before launch." >&2
       }
   fi

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -35,6 +35,8 @@ export CODEX_PERMISSIONS="$codex_permissions"
 export CODEX_APPROVAL_POLICY="$codex_approval_policy"
 export CODEX_HA_URL="http://supervisor/core"
 export CODEX_SUPERVISOR_TOKEN_FILE="/tmp/codex/ha-token"
+export CODEX_MCP_CONFIG="$CODEX_MANAGED_ROOT/mcp-servers.json"
+export CODEX_MCP_ENVIRONMENT="$CODEX_MANAGED_ROOT/mcp-environment.json"
 
 mkdir -p \
   "$CODEX_STATE_ROOT/users" \
@@ -42,6 +44,15 @@ mkdir -p \
   /tmp/codex
 
 chmod 700 /tmp/codex
+
+/usr/local/bin/codex-prepare-mcp \
+  /data/options.json \
+  "$CODEX_MCP_CONFIG" \
+  "$CODEX_MCP_ENVIRONMENT"
+chown 0:0 "$CODEX_MCP_CONFIG"
+chown 22000:0 "$CODEX_MCP_ENVIRONMENT"
+chmod 644 "$CODEX_MCP_CONFIG"
+chmod 600 "$CODEX_MCP_ENVIRONMENT"
 
 if [[ -d /homeassistant/.codex-home && ! -d "$CODEX_STATE_ROOT/legacy-global-home" ]]; then
   cp -a /homeassistant/.codex-home "$CODEX_STATE_ROOT/legacy-global-home"
@@ -125,6 +136,8 @@ When users mention `/config/...`, translate to `/homeassistant/...`
 
 Use the `homeassistant` MCP server to query entities and call services when MCP is enabled. The Supervisor token stays outside the interactive shell and is only available through the privileged `hass-mcp` helper path.
 
+Additional remote MCP servers configured in the App options are also managed in `~/.codex/config.toml`. Their bearer tokens and any additional configured environment variables are supplied to the Codex process environment.
+
 ## Reading Home Assistant Logs
 
 **Log levels (from most to least verbose):**
@@ -163,7 +176,13 @@ validate_home="$CODEX_MANAGED_ROOT/validate-home"
 rm -rf "$validate_home"
 mkdir -p "$validate_home"
 trap 'rm -rf "$validate_home"' EXIT
-/usr/local/bin/codex-merge-config "${validate_home}/config.toml" "$default_model" "$enable_mcp" "$codex_permissions" "$codex_approval_policy"
+/usr/local/bin/codex-merge-config \
+  "${validate_home}/config.toml" \
+  "$default_model" \
+  "$enable_mcp" \
+  "$codex_permissions" \
+  "$codex_approval_policy" \
+  "$CODEX_MCP_CONFIG"
 if CODEX_HOME="$validate_home" codex debug prompt-input --help >/dev/null 2>&1; then
   CODEX_HOME="$validate_home" codex debug prompt-input "startup validation" >/dev/null
 else

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -12,7 +12,7 @@ fi
 theme="$(jq -r '.terminal_theme // "dark"' /data/options.json)"
 session_persist="$(jq -r '.session_persistence // false' /data/options.json)"
 work_dir="$(jq -r '.working_directory // "/homeassistant"' /data/options.json)"
-enable_mcp="$(jq -r '.enable_mcp // true' /data/options.json)"
+enable_mcp="$(jq -r '.enable_mcp' /data/options.json)"
 default_model="$(jq -r '.default_model // ""' /data/options.json)"
 codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.json)"
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
@@ -171,10 +171,10 @@ else
 fi
 if [[ "$enable_mcp" == "true" ]]; then
   CODEX_HOME="$validate_home" codex mcp get homeassistant >/dev/null
-  echo "[INFO] Home Assistant MCP configured for Codex home"
+  echo '[INFO] Bundled MCP server registered: "homeassistant" (voska/hass-mcp)'
 else
   CODEX_HOME="$validate_home" codex mcp list >/dev/null
-  echo "[INFO] Home Assistant MCP disabled"
+  echo '[INFO] Bundled MCP server disabled: "homeassistant"'
 fi
 rm -rf "$validate_home"
 trap - EXIT
@@ -186,6 +186,7 @@ else
 fi
 
 exec ttyd \
+  --debug 3 \
   --port 7681 \
   --writable \
   --ping-interval 30 \

--- a/codex/tests/test_bundled_mcp_option.py
+++ b/codex/tests/test_bundled_mcp_option.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+START_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-start"
+MERGE_CONFIG = CODEX_DIR / "rootfs/usr/local/bin/codex-merge-config"
+
+
+class BundledMcpOptionTests(unittest.TestCase):
+    def test_explicit_false_is_not_replaced_by_default(self):
+        start_text = START_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotIn(".enable_mcp // true", start_text)
+        result = subprocess.run(
+            ["jq", "-r", ".enable_mcp"],
+            input=json.dumps({"enable_mcp": False}),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "false")
+
+    def test_disabling_bundled_mcp_removes_managed_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "config.toml"
+
+            enabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "true", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(enabled.returncode, 0, enabled.stderr)
+            self.assertIn(
+                "homeassistant",
+                tomllib.loads(config_path.read_text(encoding="utf-8"))["mcp_servers"],
+            )
+
+            disabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "false", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(disabled.returncode, 0, disabled.stderr)
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("mcp_servers", config)
+            self.assertNotIn(
+                "managed_homeassistant_mcp",
+                config.get("__homeassistant_app", {}),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/tests/test_mcp_config.py
+++ b/codex/tests/test_mcp_config.py
@@ -1,0 +1,163 @@
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+PREPARE_MCP = CODEX_DIR / "rootfs/usr/local/bin/codex-prepare-mcp"
+MERGE_CONFIG = CODEX_DIR / "rootfs/usr/local/bin/codex-merge-config"
+
+
+class McpOptionsTests(unittest.TestCase):
+    def run_prepare(self, directory, options):
+        options_path = directory / "options.json"
+        servers_path = directory / "servers.json"
+        environment_path = directory / "environment.json"
+        options_path.write_text(json.dumps(options), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, PREPARE_MCP, options_path, servers_path, environment_path],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, servers_path, environment_path
+
+    def test_prepares_remote_server_and_automatic_bearer_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            result, servers_path, environment_path = self.run_prepare(
+                directory,
+                {
+                    "mcp_servers": [
+                        {
+                            "name": "example-cloud",
+                            "url": "https://mcp.example.com/mcp",
+                            "bearer_token": "secret-token",
+                        }
+                    ],
+                    "environment_variables": [{"name": "EXAMPLE_TENANT", "value": "home"}],
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(servers_path.read_text(encoding="utf-8")),
+                [
+                    {
+                        "name": "example-cloud",
+                        "url": "https://mcp.example.com/mcp",
+                        "bearer_token_env_var": "CODEX_MCP_EXAMPLE_CLOUD_BEARER_TOKEN",
+                    }
+                ],
+            )
+            self.assertEqual(
+                json.loads(environment_path.read_text(encoding="utf-8")),
+                [
+                    {"name": "EXAMPLE_TENANT", "value": "home"},
+                    {"name": "CODEX_MCP_EXAMPLE_CLOUD_BEARER_TOKEN", "value": "secret-token"},
+                ],
+            )
+            self.assertEqual(environment_path.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn("secret-token", servers_path.read_text(encoding="utf-8"))
+
+    def test_rejects_environment_collision_with_generated_bearer_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            result, _, _ = self.run_prepare(
+                directory,
+                {
+                    "mcp_servers": [
+                        {"name": "example", "url": "https://example.com/mcp", "bearer_token": "secret"}
+                    ],
+                    "environment_variables": [
+                        {"name": "CODEX_MCP_EXAMPLE_BEARER_TOKEN", "value": "other"}
+                    ],
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("conflicts", result.stderr)
+
+
+class McpMergeTests(unittest.TestCase):
+    def run_merge(self, config_path, servers_path):
+        return subprocess.run(
+            [
+                sys.executable,
+                MERGE_CONFIG,
+                config_path,
+                "",
+                "true",
+                "workspace",
+                "on-request",
+                servers_path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_adds_managed_server_without_secret_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            config_path = directory / "config.toml"
+            servers_path = directory / "servers.json"
+            servers_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "example",
+                            "url": "https://example.com/mcp",
+                            "bearer_token_env_var": "CODEX_MCP_EXAMPLE_BEARER_TOKEN",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_merge(config_path, servers_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            config_text = config_path.read_text(encoding="utf-8")
+            config = tomllib.loads(config_text)
+            self.assertEqual(config["mcp_servers"]["example"]["url"], "https://example.com/mcp")
+            self.assertEqual(
+                config["mcp_servers"]["example"]["bearer_token_env_var"],
+                "CODEX_MCP_EXAMPLE_BEARER_TOKEN",
+            )
+            self.assertNotIn("secret", config_text)
+
+    def test_restores_preexisting_same_name_server_when_management_is_removed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            config_path = directory / "config.toml"
+            servers_path = directory / "servers.json"
+            config_path.write_text(
+                '[mcp_servers.example]\ncommand = "original-command"\nargs = ["serve"]\n',
+                encoding="utf-8",
+            )
+            servers_path.write_text(
+                json.dumps([{"name": "example", "url": "https://example.com/mcp"}]),
+                encoding="utf-8",
+            )
+
+            first_result = self.run_merge(config_path, servers_path)
+            self.assertEqual(first_result.returncode, 0, first_result.stderr)
+            managed_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("command", managed_config["mcp_servers"]["example"])
+
+            servers_path.write_text("[]\n", encoding="utf-8")
+            second_result = self.run_merge(config_path, servers_path)
+
+            self.assertEqual(second_result.returncode, 0, second_result.stderr)
+            restored_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(restored_config["mcp_servers"]["example"]["command"], "original-command")
+            self.assertEqual(restored_config["mcp_servers"]["example"]["args"], ["serve"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/translations/en.yaml
+++ b/codex/translations/en.yaml
@@ -53,6 +53,35 @@ configuration:
     description: >-
       Maximum seconds to wait for the optional Codex CLI startup update.
       Applies only when auto-update is enabled.
+  mcp_servers:
+    name: Remote MCP Servers
+    description: >-
+      Streamable HTTP MCP servers to add to Codex. For each non-empty bearer
+      token, the App automatically creates a protected environment variable
+      and configures bearer_token_env_var for that server.
+    fields:
+      name:
+        name: Server Name
+        description: Unique Codex MCP server name. The name homeassistant is reserved.
+      url:
+        name: Server URL
+        description: Streamable HTTP MCP endpoint beginning with http:// or https://.
+      bearer_token:
+        name: Bearer Token
+        description: Optional token; the App automatically passes it through an environment variable.
+  environment_variables:
+    name: Environment Variables
+    description: >-
+      Additional environment variables for Codex and its MCP servers. Values
+      are treated as secrets in the App options and are available to Codex
+      sessions.
+    fields:
+      name:
+        name: Variable Name
+        description: Environment variable name using letters, digits, and underscores.
+      value:
+        name: Variable Value
+        description: Value made available to Codex and its MCP servers.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/codex/translations/es.yaml
+++ b/codex/translations/es.yaml
@@ -56,6 +56,34 @@ configuration:
     description: >-
       Segundos máximos para esperar la actualización opcional de Codex CLI al
       iniciar. Solo aplica cuando la actualización automática está habilitada.
+  mcp_servers:
+    name: Servidores MCP remotos
+    description: >-
+      Servidores MCP HTTP Streamable que se añadirán a Codex. Para cada token
+      bearer no vacío, la App crea automáticamente una variable de entorno
+      protegida y configura bearer_token_env_var para ese servidor.
+    fields:
+      name:
+        name: Nombre del servidor
+        description: Nombre único del servidor MCP de Codex. homeassistant está reservado.
+      url:
+        name: URL del servidor
+        description: Endpoint MCP HTTP Streamable que comienza con http:// o https://.
+      bearer_token:
+        name: Token bearer
+        description: Token opcional que la App pasa automáticamente mediante una variable de entorno.
+  environment_variables:
+    name: Variables de entorno
+    description: >-
+      Variables de entorno adicionales para Codex y sus servidores MCP. Los
+      valores se tratan como secretos y están disponibles en sesiones de Codex.
+    fields:
+      name:
+        name: Nombre de la variable
+        description: Nombre de variable de entorno con letras, números y guiones bajos.
+      value:
+        name: Valor de la variable
+        description: Valor disponible para Codex y sus servidores MCP.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/codex/translations/pt-BR.yaml
+++ b/codex/translations/pt-BR.yaml
@@ -56,6 +56,34 @@ configuration:
       Segundos máximos para aguardar a atualização opcional do Codex CLI na
       inicialização. Aplica-se apenas quando a atualização automática está
       habilitada.
+  mcp_servers:
+    name: Servidores MCP remotos
+    description: >-
+      Servidores MCP HTTP Streamable que serão adicionados ao Codex. Para cada
+      bearer token não vazio, o App cria automaticamente uma variável de
+      ambiente protegida e configura bearer_token_env_var para o servidor.
+    fields:
+      name:
+        name: Nome do servidor
+        description: Nome exclusivo do servidor MCP do Codex. homeassistant é reservado.
+      url:
+        name: URL do servidor
+        description: Endpoint MCP HTTP Streamable iniciado por http:// ou https://.
+      bearer_token:
+        name: Bearer token
+        description: Token opcional que o App passa automaticamente por uma variável de ambiente.
+  environment_variables:
+    name: Variáveis de ambiente
+    description: >-
+      Variáveis de ambiente adicionais para o Codex e seus servidores MCP. Os
+      valores são tratados como segredos e ficam disponíveis nas sessões do Codex.
+    fields:
+      name:
+        name: Nome da variável
+        description: Nome de variável de ambiente com letras, números e sublinhados.
+      value:
+        name: Valor da variável
+        description: Valor disponibilizado ao Codex e aos servidores MCP.
 
 network:
   7681/tcp: Terminal Web (ttyd)


### PR DESCRIPTION
## Summary

- add App options for managed remote Streamable HTTP MCP servers
- add explicitly configured environment variables to Codex sessions
- keep bearer-token values out of `config.toml` by referencing generated environment-variable names
- merge and remove managed servers reversibly, restoring pre-existing same-name user configuration
- validate names, URLs, collisions, and generated runtime data
- document networking and security behavior and add translations and regression tests

## Testing

- `python3 -B -m unittest discover -s codex/tests -v`
- `bash -n codex/rootfs/usr/local/bin/codex-start codex/rootfs/usr/local/bin/codex-shell`
- parsed App, repository, and translation YAML
- `git diff --check`

## Dependency

Depends on #6, which fixes explicit `enable_mcp: false` handling used by this feature.

This is intentionally a stacked draft. The first commit is #6; the remote-MCP implementation is the following commit. After #6 merges, this branch can be rebased onto `main` so the PR shows only the remote-MCP change.
