### PR TITLE
feat(codex): add optional SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Manual install:
 - Direct access to `/homeassistant`, `/share`, and `/media`.
 - Read-only access to `/ssl` and `/backup`.
 - Optional Home Assistant MCP integration for entity lookup and service calls.
+- App options for additional remote MCP servers, bearer tokens, and environment variables.
 - Persistent Codex auth and settings under `/data/codex-home`.
-- Home Assistant options for model default, sandbox access, MCP, terminal theme, and session persistence.
+- Home Assistant options for model default, sandbox access, MCP servers, environment variables, terminal theme, and session persistence.
 
 ## Authentication
 
-Codex authentication happens inside the terminal. Home Assistant does not store your OpenAI API key, ChatGPT session, or Codex access token in App options.
+Codex authentication normally happens inside the terminal, so Home Assistant does not need to store your OpenAI API key, ChatGPT session, or Codex access token in App options. Credentials deliberately added through the optional MCP or environment-variable settings are stored as App options.
 
 On first launch, Codex prompts you to sign in. The Codex CLI supports ChatGPT sign-in for subscription access and API-key sign-in for usage-based access. On headless or remote systems, use the Codex device-code login option if the normal browser callback flow cannot complete.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Manual install:
 
 - OpenAI Codex CLI running in Home Assistant.
 - A web terminal served through Home Assistant ingress.
+- Optional LAN/VPN SSH access as the same unprivileged `codex` user.
 - Prebuilt GHCR images for faster installs and Home Assistant updates.
 - Direct access to `/homeassistant`, `/share`, and `/media`.
 - Read-only access to `/ssl` and `/backup`.

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.18] - 2026-08-26
+
+### Added
+- Add optional OpenSSH access for the existing unprivileged `codex` user with simultaneous password and public-key authentication
+- Add a disabled-by-default `22/tcp` port mapping, persistent SSH host keys under `/data/ssh`, and App options for enabling SSH and configuring credentials
+
+### Changed
+- Share the persistent Codex home, managed MCP configuration, and environment variables between web-terminal and SSH sessions
+
 ## [0.2.17] - 2026-08-26
 
 ### Added

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.17] - 2026-08-26
+
+### Added
+- Add App options for managed remote Streamable HTTP MCP servers and additional Codex environment variables
+- Create a per-server environment variable and configure `bearer_token_env_var` whenever an MCP bearer token is supplied
+
+### Changed
+- Merge managed remote MCP servers into each persistent Codex user configuration and restore a pre-existing same-name server when App management is removed
+- Make configured environment variables available to Codex sessions without writing their values to `config.toml`
+
 ## [0.2.16] - 2026-08-26
 
 ### Fixed

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.16] - 2026-08-26
+
+### Fixed
+- Preserve an explicit `enable_mcp: false` App option so the bundled Home Assistant MCP server remains disabled
+- Report the effective bundled MCP state clearly during startup
+- Limit routine ttyd and libwebsockets connection logging to warnings and errors
+
 ## [0.2.15] - 2026-05-31
 
 ### Fixed

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add --no-cache \
     nodejs \
     npm \
     openssh-client \
+    openssh-server \
     openssl \
     p7zip \
     ripgrep \
@@ -67,7 +68,7 @@ RUN case "${BUILD_ARCH}" in \
     curl -fsSL "https://github.com/home-assistant/cli/releases/latest/download/ha_${HA_ARCH}" -o /usr/local/bin/ha && \
     chmod +x /usr/local/bin/ha
 
-RUN adduser -D -H -u 22000 -G root codex && \
+RUN adduser -D -H -h /data/codex-home/users/anonymous -s /bin/bash -u 22000 -G root codex && \
     mkdir -p \
     /data/codex-home \
     /data/codex-managed \
@@ -76,7 +77,7 @@ RUN adduser -D -H -u 22000 -G root codex && \
 
 COPY rootfs/ /
 
-RUN chmod +x \
+RUN chmod 755 \
     /usr/local/bin/hass-mcp-wrapper \
     /usr/local/bin/hass-mcp-root-helper \
     /usr/local/bin/codex-merge-config \
@@ -84,6 +85,9 @@ RUN chmod +x \
     /usr/local/bin/codex-shell \
     /usr/local/bin/codex-session \
     /usr/local/bin/codex-start \
+    && chmod 644 \
+    /etc/profile.d/codex.sh \
+    /etc/ssh/sshd_config \
     && chmod 440 /etc/sudoers.d/codex-hass-mcp
 
 RUN cat > /etc/tmux.conf << 'EOF'

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod +x \
     /usr/local/bin/hass-mcp-wrapper \
     /usr/local/bin/hass-mcp-root-helper \
     /usr/local/bin/codex-merge-config \
+    /usr/local/bin/codex-prepare-mcp \
     /usr/local/bin/codex-shell \
     /usr/local/bin/codex-session \
     /usr/local/bin/codex-start \

--- a/codex/README.md
+++ b/codex/README.md
@@ -13,8 +13,9 @@ It is designed as a Home Assistant-native App, not a copied terminal wrapper. Th
 5. The App generates user-level Codex defaults in `~/.codex/config.toml`.
 6. The App generates `~/.codex/AGENTS.md` with Home Assistant path mapping, log commands, and MCP notes.
 7. If MCP is enabled, Codex gets a managed `homeassistant` MCP server that talks to Home Assistant through `hass-mcp`.
+8. Remote MCP servers and their environment variables configured in the App options are added to every Codex session.
 
-The App keeps OpenAI credentials out of Home Assistant options. Codex signs in using its own CLI authentication flow and stores its own auth state in the persistent Codex home.
+By default, the App keeps OpenAI credentials out of Home Assistant options. Codex signs in using its own CLI authentication flow and stores its own auth state in the persistent Codex home. Credentials deliberately added through `environment_variables` or an MCP `bearer_token` are stored as App options.
 
 ## Install
 
@@ -79,6 +80,8 @@ When Codex or a prompt mentions `/config`, treat it as `/homeassistant` in this 
 | `codex_approval_policy` | `on-request` | Selects when Codex asks before running actions |
 | `auto_update_codex` | `false` | Optionally updates Codex CLI at startup |
 | `codex_update_timeout` | `300` | Maximum seconds for the optional startup update |
+| `mcp_servers` | `[]` | Adds managed remote Streamable HTTP MCP servers to Codex |
+| `environment_variables` | `[]` | Adds environment variables to Codex sessions |
 
 ## Models
 
@@ -130,6 +133,28 @@ When `enable_mcp` is `true`, the App registers a `homeassistant` MCP server in C
 The Supervisor token is not exported into the interactive shell. It is written to a protected runtime file and passed only through the helper path used by `hass-mcp`.
 
 Disable MCP if you only want a terminal and file-editing workflow.
+
+## Additional MCP Servers and Environment Variables
+
+Remote Streamable HTTP MCP servers can be created directly in the App options. Restart the App after changing the list:
+
+```yaml
+mcp_servers:
+  - name: example
+    url: https://mcp.example.com/mcp
+    bearer_token: "your-token"
+environment_variables:
+  - name: EXAMPLE_TENANT
+    value: "home"
+```
+
+`name` must be unique; `homeassistant` is reserved for the built-in integration. URLs must start with `http://` or `https://`.
+
+When `bearer_token` is set, the App automatically creates an environment variable named `CODEX_MCP_<SERVER_NAME>_BEARER_TOKEN` and writes that name as the server's `bearer_token_env_var` in Codex configuration. For example, the server above uses `CODEX_MCP_EXAMPLE_BEARER_TOKEN`. The token value is not written to `config.toml`.
+
+Entries under `environment_variables` are also exported to Codex sessions. Variable names must use letters, digits, and underscores and cannot start with a digit. Their values and bearer tokens are stored in Home Assistant App options and are available to the unprivileged `codex` runtime user, so only add credentials that Codex and its MCP servers are intended to use.
+
+Removing a managed MCP server from the App options removes it from Codex on the next App restart. If an existing user-defined server had the same name before App management began, its previous configuration is restored.
 
 ## Persistence
 
@@ -247,6 +272,8 @@ Version `0.2.13` removes that incompatible UI state automatically and keeps the 
 3. In Codex, check whether the `homeassistant` MCP server appears.
 4. Check the App log for `hass-mcp` or Supervisor token errors.
 
+For an additional MCP server, also confirm that its name is unique, its URL starts with `http://` or `https://`, and the App was restarted after editing `mcp_servers` or `environment_variables`.
+
 ### Project config is ignored
 
 1. Confirm the file is `/homeassistant/.codex/config.toml`.
@@ -263,6 +290,7 @@ Disable `auto_update_codex` unless you specifically need the newest CLI on every
 - [Codex authentication](https://developers.openai.com/codex/auth)
 - [Codex config basics](https://developers.openai.com/codex/config-basic)
 - [Codex config reference](https://developers.openai.com/codex/config-reference)
+- [Codex MCP configuration](https://developers.openai.com/codex/mcp)
 
 ## Support
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ It is designed as a Home Assistant-native App, not a copied terminal wrapper. Th
 6. The App generates `~/.codex/AGENTS.md` with Home Assistant path mapping, log commands, and MCP notes.
 7. If MCP is enabled, Codex gets a managed `homeassistant` MCP server that talks to Home Assistant through `hass-mcp`.
 8. Remote MCP servers and their environment variables configured in the App options are added to every Codex session.
+9. If SSH is enabled, OpenSSH accepts logins as `codex` on container port `22` and uses the same persistent home as the web terminal.
 
 By default, the App keeps OpenAI credentials out of Home Assistant options. Codex signs in using its own CLI authentication flow and stores its own auth state in the persistent Codex home. Credentials deliberately added through `environment_variables` or an MCP `bearer_token` are stored as App options.
 
@@ -80,8 +81,34 @@ When Codex or a prompt mentions `/config`, treat it as `/homeassistant` in this 
 | `codex_approval_policy` | `on-request` | Selects when Codex asks before running actions |
 | `auto_update_codex` | `false` | Optionally updates Codex CLI at startup |
 | `codex_update_timeout` | `300` | Maximum seconds for the optional startup update |
+| `ssh_enabled` | `false` | Starts the SSH server when enabled |
+| `ssh_password` | empty | Sets the `codex` SSH password; the UI masks this field |
+| `authorized_keys` | `[]` | Lists public keys accepted for the `codex` SSH user |
 | `mcp_servers` | `[]` | Adds managed remote Streamable HTTP MCP servers to Codex |
-| `environment_variables` | `[]` | Adds environment variables to Codex sessions |
+| `environment_variables` | `[]` | Adds environment variables to web-terminal and SSH Codex sessions |
+
+## SSH Access
+
+SSH is disabled by default. To enable it:
+
+1. Set `ssh_enabled: true` in the App options.
+2. Set `ssh_password`, add one or more `authorized_keys`, or configure both.
+3. In the App's **Network** settings, map container port `22/tcp` to an unused host port such as `2222`.
+4. Restart the App.
+
+Then connect from another machine:
+
+```bash
+ssh -p 2222 codex@homeassistant.local
+```
+
+At startup the App reports the effective host mapping, for example host port
+`2222` mapped to container port `22`. Port `22` remains the internal OpenSSH
+port; clients connect to the host port selected in the Network section.
+
+The SSH user is fixed as `codex` so it can reuse the existing unprivileged web-terminal identity. SSH and the web terminal share `/data/codex-home/users/anonymous`, including Codex authentication, configuration, and the persistent user npm prefix. Password and public-key login may be enabled at the same time. If neither is configured, the daemon can start but no remote login credential is available.
+
+SSH host keys persist under `/data/ssh`, so the server fingerprint remains stable across App restarts and image updates. Root login, empty-password login, X11 forwarding, agent forwarding, TCP forwarding, tunnels, and user-supplied SSH environments are disabled.
 
 ## Models
 
@@ -152,7 +179,7 @@ environment_variables:
 
 When `bearer_token` is set, the App automatically creates an environment variable named `CODEX_MCP_<SERVER_NAME>_BEARER_TOKEN` and writes that name as the server's `bearer_token_env_var` in Codex configuration. For example, the server above uses `CODEX_MCP_EXAMPLE_BEARER_TOKEN`. The token value is not written to `config.toml`.
 
-Entries under `environment_variables` are also exported to Codex sessions. Variable names must use letters, digits, and underscores and cannot start with a digit. Their values and bearer tokens are stored in Home Assistant App options and are available to the unprivileged `codex` runtime user, so only add credentials that Codex and its MCP servers are intended to use.
+Entries under `environment_variables` are also exported to Codex in both web-terminal and SSH sessions. Variable names must use letters, digits, and underscores and cannot start with a digit. Their values and bearer tokens are stored in Home Assistant App options and are available to the unprivileged `codex` runtime user, so only add credentials that Codex and its MCP servers are intended to use.
 
 Removing a managed MCP server from the App options removes it from Codex on the next App restart. If an existing user-defined server had the same name before App management began, its previous configuration is restored.
 

--- a/codex/apparmor.txt
+++ b/codex/apparmor.txt
@@ -5,8 +5,10 @@ profile codex flags=(attach_disconnected,mediate_deleted) {
 
   # Capabilities needed for terminal and outbound networking
   capability net_raw,
+  capability net_bind_service,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability chown,
   capability fowner,
   capability dac_override,
@@ -26,6 +28,16 @@ profile codex flags=(attach_disconnected,mediate_deleted) {
 
   # System files (read-only)
   /etc/** r,
+  # Password changes for the fixed, unprivileged SSH account
+  /etc/.pwd.lock rwk,
+  /etc/passwd rwk,
+  /etc/passwd+ rw,
+  /etc/passwd- rw,
+  /etc/shadow rwk,
+  /etc/shadow+ rw,
+  /etc/shadow- rw,
+  link /etc/passwd- -> /etc/passwd,
+  link /etc/shadow- -> /etc/shadow,
   /usr/** r,
   /lib/** r,
   /proc/** r,
@@ -65,6 +77,10 @@ profile codex flags=(attach_disconnected,mediate_deleted) {
   /root/ r,
   /root/** rwk,
   /tmp/** rwk,
+
+  # OpenSSH privilege-separation runtime directory
+  /run/sshd/ rw,
+  /run/sshd/** rwk,
 
   # Node.js modules
   /usr/lib/node_modules/** ixmr,

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.17"
+version: "0.2.18"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass
@@ -13,6 +13,8 @@ init: true
 ingress: true
 ingress_port: 7681
 ingress_stream: true
+ports:
+  22/tcp: null
 panel_icon: mdi:code-braces
 panel_title: Codex
 homeassistant_api: true
@@ -37,6 +39,9 @@ options:
   codex_approval_policy: on-request
   auto_update_codex: false
   codex_update_timeout: 300
+  ssh_enabled: false
+  ssh_password: ""
+  authorized_keys: []
   mcp_servers: []
   environment_variables: []
 schema:
@@ -50,6 +55,10 @@ schema:
   codex_approval_policy: list(on-request|never|untrusted)
   auto_update_codex: bool
   codex_update_timeout: int(30,300)
+  ssh_enabled: bool
+  ssh_password: password
+  authorized_keys:
+    - str
   mcp_servers:
     - name: str
       url: url

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.16"
+version: "0.2.17"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass
@@ -37,6 +37,8 @@ options:
   codex_approval_policy: on-request
   auto_update_codex: false
   codex_update_timeout: 300
+  mcp_servers: []
+  environment_variables: []
 schema:
   enable_mcp: bool
   terminal_font_size: int(10,24)
@@ -48,5 +50,12 @@ schema:
   codex_approval_policy: list(on-request|never|untrusted)
   auto_update_codex: bool
   codex_update_timeout: int(30,300)
+  mcp_servers:
+    - name: str
+      url: url
+      bearer_token: password?
+  environment_variables:
+    - name: str
+      value: password
 environment:
   TERM: xterm-256color

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,6 +1,6 @@
 name: Codex
 description: OpenAI Codex App for Home Assistant with terminal access, model controls, and optional Home Assistant MCP integration
-version: "0.2.15"
+version: "0.2.16"
 slug: codex
 url: https://github.com/kecksdigital/codex-hass
 image: ghcr.io/kecksdigital/codex-hass

--- a/codex/rootfs/etc/profile.d/codex.sh
+++ b/codex/rootfs/etc/profile.d/codex.sh
@@ -1,0 +1,44 @@
+if [ "$(id -u)" -eq 22000 ]; then
+    export HOME=/data/codex-home/users/anonymous
+    export CODEX_HOME="${HOME}/.codex"
+    export CODEX_STATE_ROOT=/data/codex-home
+    export CODEX_MANAGED_ROOT=/data/codex-managed
+    export CODEX_HA_URL=http://supervisor/core
+    export CODEX_SUPERVISOR_TOKEN_FILE=/tmp/codex/ha-token
+    export CODEX_MCP_CONFIG=/data/codex-managed/mcp-servers.json
+    export CODEX_MCP_ENVIRONMENT=/data/codex-managed/mcp-environment.json
+    export NPM_CONFIG_CACHE="${HOME}/.npm"
+    export NPM_CONFIG_PREFIX="${HOME}/.local"
+    export PATH="${NPM_CONFIG_PREFIX}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    if [ -r /data/codex-managed/session-options.json ]; then
+        export CODEX_WORK_DIR="$(jq -r '.working_directory // "/homeassistant"' /data/codex-managed/session-options.json)"
+        export CODEX_DEFAULT_MODEL="$(jq -r '.default_model // ""' /data/codex-managed/session-options.json)"
+        export CODEX_ENABLE_MCP="$(jq -r '.enable_mcp' /data/codex-managed/session-options.json)"
+        export CODEX_PERMISSIONS="$(jq -r '.codex_permissions // "workspace"' /data/codex-managed/session-options.json)"
+        export CODEX_APPROVAL_POLICY="$(jq -r '.codex_approval_policy // "on-request"' /data/codex-managed/session-options.json)"
+    else
+        export CODEX_WORK_DIR=/homeassistant
+        export CODEX_ENABLE_MCP=true
+        export CODEX_PERMISSIONS=workspace
+        export CODEX_APPROVAL_POLICY=on-request
+    fi
+
+    if [ -r "$CODEX_MCP_ENVIRONMENT" ]; then
+        while IFS= read -r -d '' env_name && IFS= read -r -d '' env_value; do
+            case "$env_name" in
+                ''|[0-9]*|*[!A-Za-z0-9_]*) continue ;;
+            esac
+            export "$env_name=$env_value"
+        done < <(jq -j '.[] | .name, "\u0000", .value, "\u0000"' "$CODEX_MCP_ENVIRONMENT")
+        unset env_name env_value
+    fi
+
+    source /etc/codex.bashrc
+
+    if [ -d "${CODEX_WORK_DIR}" ]; then
+        cd "${CODEX_WORK_DIR}"
+    else
+        cd /homeassistant
+    fi
+fi

--- a/codex/rootfs/etc/ssh/sshd_config
+++ b/codex/rootfs/etc/ssh/sshd_config
@@ -1,0 +1,30 @@
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
+
+HostKey /data/ssh/ssh_host_ed25519_key
+HostKey /data/ssh/ssh_host_rsa_key
+PidFile /tmp/codex/sshd.pid
+
+PermitRootLogin no
+AllowUsers codex
+StrictModes yes
+PermitEmptyPasswords no
+PasswordAuthentication yes
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+KbdInteractiveAuthentication no
+
+X11Forwarding no
+AllowAgentForwarding no
+AllowTcpForwarding no
+AllowStreamLocalForwarding no
+DisableForwarding yes
+GatewayPorts no
+PermitTunnel no
+PermitUserEnvironment no
+PermitUserRC no
+
+PrintMotd no
+UseDNS no

--- a/codex/rootfs/usr/local/bin/codex-merge-config
+++ b/codex/rootfs/usr/local/bin/codex-merge-config
@@ -135,10 +135,48 @@ def repair_incompatible_codex_values(config):
     return repaired
 
 
+def load_managed_mcp_servers(path):
+    if path is None:
+        return []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Unable to read managed MCP servers from {path}: {error}") from error
+
+    if not isinstance(loaded, list):
+        raise ValueError("Managed MCP server configuration must be a list")
+
+    servers = []
+    names = set()
+    for index, item in enumerate(loaded):
+        if not isinstance(item, dict):
+            raise ValueError(f"Managed MCP server {index} must be an object")
+        name = item.get("name")
+        url = item.get("url")
+        bearer_token_env_var = item.get("bearer_token_env_var")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Managed MCP server {index} has an invalid name")
+        if name == "homeassistant":
+            raise ValueError("Managed MCP server name 'homeassistant' is reserved")
+        if name in names:
+            raise ValueError(f"Duplicate managed MCP server name: {name}")
+        if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            raise ValueError(f"Managed MCP server {name!r} has an invalid URL")
+        if bearer_token_env_var is not None and (
+            not isinstance(bearer_token_env_var, str) or not bearer_token_env_var
+        ):
+            raise ValueError(f"Managed MCP server {name!r} has an invalid bearer token environment variable")
+        names.add(name)
+        servers.append(item)
+    return servers
+
+
 def main():
-    if len(sys.argv) not in (4, 5, 6):
+    if len(sys.argv) not in (4, 5, 6, 7):
         print(
-            "usage: codex-merge-config <config_path> <default_model> <enable_mcp> [codex_permissions] [codex_approval_policy]",
+            "usage: codex-merge-config <config_path> <default_model> <enable_mcp> "
+            "[codex_permissions] [codex_approval_policy] [managed_mcp_path]",
             file=sys.stderr,
         )
         return 1
@@ -147,7 +185,14 @@ def main():
     default_model = sys.argv[2]
     enable_mcp = sys.argv[3].lower() == "true"
     codex_permissions = sys.argv[4] if len(sys.argv) >= 5 else "workspace"
-    codex_approval_policy = sys.argv[5] if len(sys.argv) == 6 else "on-request"
+    codex_approval_policy = sys.argv[5] if len(sys.argv) >= 6 else "on-request"
+    managed_mcp_path = Path(sys.argv[6]) if len(sys.argv) == 7 and sys.argv[6] else None
+
+    try:
+        managed_mcp_servers = load_managed_mcp_servers(managed_mcp_path)
+    except ValueError as error:
+        print(f"[ERROR] {error}", file=sys.stderr)
+        return 1
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config = load_existing_config(config_path)
@@ -249,6 +294,51 @@ def main():
             metadata["managed_homeassistant_mcp_backup"] = dict(existing_homeassistant)
         mcp_servers.pop("homeassistant", None)
         metadata.pop("managed_homeassistant_mcp", None)
+
+    previous_custom_names = metadata.get("managed_custom_mcp_servers", [])
+    if not isinstance(previous_custom_names, list):
+        previous_custom_names = []
+    previous_custom_names = {
+        name for name in previous_custom_names if isinstance(name, str) and name != "homeassistant"
+    }
+    custom_backups = metadata.get("managed_custom_mcp_backups", {})
+    if not isinstance(custom_backups, dict):
+        custom_backups = {}
+
+    desired_custom_servers = {server["name"]: server for server in managed_mcp_servers}
+    for name in previous_custom_names - desired_custom_servers.keys():
+        mcp_servers.pop(name, None)
+        backup = custom_backups.pop(name, None)
+        if isinstance(backup, dict):
+            mcp_servers[name] = backup
+
+    stdio_only_keys = ("command", "args", "env", "env_vars", "cwd", "experimental_environment")
+    for name, managed_server in desired_custom_servers.items():
+        existing = mcp_servers.get(name, {})
+        if not isinstance(existing, dict):
+            existing = {}
+        if name not in previous_custom_names and existing:
+            custom_backups[name] = dict(existing)
+
+        merged_server = dict(existing)
+        for key in stdio_only_keys:
+            merged_server.pop(key, None)
+        merged_server["url"] = managed_server["url"]
+        bearer_token_env_var = managed_server.get("bearer_token_env_var")
+        if bearer_token_env_var:
+            merged_server["bearer_token_env_var"] = bearer_token_env_var
+        else:
+            merged_server.pop("bearer_token_env_var", None)
+        mcp_servers[name] = merged_server
+
+    if desired_custom_servers:
+        metadata["managed_custom_mcp_servers"] = list(desired_custom_servers)
+    else:
+        metadata.pop("managed_custom_mcp_servers", None)
+    if custom_backups:
+        metadata["managed_custom_mcp_backups"] = custom_backups
+    else:
+        metadata.pop("managed_custom_mcp_backups", None)
 
     if not mcp_servers:
         config.pop("mcp_servers", None)

--- a/codex/rootfs/usr/local/bin/codex-prepare-mcp
+++ b/codex/rootfs/usr/local/bin/codex-prepare-mcp
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def fail(message):
+    print(f"[ERROR] {message}", file=sys.stderr)
+    return 1
+
+
+def write_json_atomic(path, value, mode):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def bearer_env_name(server_name):
+    normalized = re.sub(r"[^A-Za-z0-9_]", "_", server_name).upper()
+    if not normalized or normalized[0].isdigit():
+        normalized = f"_{normalized}"
+    return f"CODEX_MCP_{normalized}_BEARER_TOKEN"
+
+
+def read_string(mapping, key, context, required=False):
+    value = mapping.get(key, "")
+    if not isinstance(value, str):
+        raise ValueError(f"{context}.{key} must be a string")
+    if required and not value.strip():
+        raise ValueError(f"{context}.{key} must not be empty")
+    return value
+
+
+def prepare(options):
+    configured_servers = options.get("mcp_servers", [])
+    configured_environment = options.get("environment_variables", [])
+    if not isinstance(configured_servers, list):
+        raise ValueError("mcp_servers must be a list")
+    if not isinstance(configured_environment, list):
+        raise ValueError("environment_variables must be a list")
+
+    servers = []
+    environment = []
+    server_names = set()
+    environment_names = set()
+
+    for index, item in enumerate(configured_environment):
+        context = f"environment_variables[{index}]"
+        if not isinstance(item, dict):
+            raise ValueError(f"{context} must be an object")
+        name = read_string(item, "name", context, required=True)
+        value = read_string(item, "value", context)
+        if not ENV_NAME_RE.fullmatch(name):
+            raise ValueError(f"{context}.name is not a valid environment variable name: {name!r}")
+        if name in environment_names:
+            raise ValueError(f"duplicate environment variable: {name}")
+        environment_names.add(name)
+        environment.append({"name": name, "value": value})
+
+    for index, item in enumerate(configured_servers):
+        context = f"mcp_servers[{index}]"
+        if not isinstance(item, dict):
+            raise ValueError(f"{context} must be an object")
+        name = read_string(item, "name", context, required=True)
+        url = read_string(item, "url", context, required=True)
+        bearer_token = read_string(item, "bearer_token", context)
+        if name == "homeassistant":
+            raise ValueError("mcp_servers name 'homeassistant' is reserved for the built-in server")
+        if name in server_names:
+            raise ValueError(f"duplicate MCP server name: {name}")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"{context}.url must start with http:// or https://")
+
+        server = {"name": name, "url": url}
+        if bearer_token:
+            env_name = bearer_env_name(name)
+            if env_name in environment_names:
+                raise ValueError(
+                    f"generated bearer-token environment variable conflicts with environment_variables: {env_name}"
+                )
+            environment_names.add(env_name)
+            environment.append({"name": env_name, "value": bearer_token})
+            server["bearer_token_env_var"] = env_name
+
+        server_names.add(name)
+        servers.append(server)
+
+    return servers, environment
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(
+            "usage: codex-prepare-mcp <options_path> <servers_path> <environment_path>",
+            file=sys.stderr,
+        )
+        return 1
+
+    options_path = Path(sys.argv[1])
+    servers_path = Path(sys.argv[2])
+    environment_path = Path(sys.argv[3])
+    try:
+        with options_path.open("r", encoding="utf-8") as handle:
+            options = json.load(handle)
+        if not isinstance(options, dict):
+            return fail("App options must contain a JSON object")
+        servers, environment = prepare(options)
+        write_json_atomic(servers_path, servers, 0o644)
+        write_json_atomic(environment_path, environment, 0o600)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        return fail(f"Unable to prepare custom MCP configuration: {error}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/rootfs/usr/local/bin/codex-session
+++ b/codex/rootfs/usr/local/bin/codex-session
@@ -64,6 +64,8 @@ default_model="${CODEX_DEFAULT_MODEL:-}"
 enable_mcp="${CODEX_ENABLE_MCP:-true}"
 codex_permissions="${CODEX_PERMISSIONS:-workspace}"
 codex_approval_policy="${CODEX_APPROVAL_POLICY:-on-request}"
+managed_mcp_config="${CODEX_MCP_CONFIG:-${managed_root}/mcp-servers.json}"
+managed_mcp_environment="${CODEX_MCP_ENVIRONMENT:-${managed_root}/mcp-environment.json}"
 session_uid=22000
 system_user="codex"
 session_gid=0
@@ -95,7 +97,13 @@ cleanup_config_lock() {
 
 trap cleanup_config_lock EXIT
 
-/usr/local/bin/codex-merge-config "${user_codex_home}/config.toml" "$default_model" "$enable_mcp" "$codex_permissions" "$codex_approval_policy"
+/usr/local/bin/codex-merge-config \
+  "${user_codex_home}/config.toml" \
+  "$default_model" \
+  "$enable_mcp" \
+  "$codex_permissions" \
+  "$codex_approval_policy" \
+  "$managed_mcp_config"
 merge_status=$?
 if [[ "$merge_status" -ne 0 ]]; then
   cleanup_config_lock
@@ -135,6 +143,8 @@ session_env=(
   "CODEX_ENABLE_MCP=$enable_mcp"
   "CODEX_PERMISSIONS=$codex_permissions"
   "CODEX_APPROVAL_POLICY=$codex_approval_policy"
+  "CODEX_MCP_CONFIG=$managed_mcp_config"
+  "CODEX_MCP_ENVIRONMENT=$managed_mcp_environment"
   "CODEX_USER_ID=$safe_user"
   "CODEX_WORK_DIR=$work_dir"
   "LOGNAME=$system_user"
@@ -146,6 +156,14 @@ session_env=(
   "TMUX_TMPDIR=$user_root"
   "USER=$system_user"
 )
+
+if [[ -r "$managed_mcp_environment" ]]; then
+  while IFS= read -r -d '' env_name && IFS= read -r -d '' env_value; do
+    if [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      session_env+=("$env_name=$env_value")
+    fi
+  done < <(jq -j '.[] | .name, "\u0000", .value, "\u0000"' "$managed_mcp_environment")
+fi
 
 if [[ "$session_persist" == "true" ]]; then
   tmux_socket="${user_root}/tmux.sock"

--- a/codex/rootfs/usr/local/bin/codex-shell
+++ b/codex/rootfs/usr/local/bin/codex-shell
@@ -19,7 +19,8 @@ repair_codex_config() {
       "${CODEX_DEFAULT_MODEL:-}" \
       "${CODEX_ENABLE_MCP:-true}" \
       "${CODEX_PERMISSIONS:-workspace}" \
-      "${CODEX_APPROVAL_POLICY:-on-request}" || {
+      "${CODEX_APPROVAL_POLICY:-on-request}" \
+      "${CODEX_MCP_CONFIG:-/data/codex-managed/mcp-servers.json}" || {
         echo "[WARN] Unable to repair Codex config before launch." >&2
       }
   fi

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -18,6 +18,21 @@ codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.jso
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
 auto_update_codex="$(jq -r '.auto_update_codex // false' /data/options.json)"
 codex_update_timeout="$(jq -r '.codex_update_timeout // 300' /data/options.json)"
+ssh_enabled="$(jq -r '.ssh_enabled // false' /data/options.json)"
+ssh_host_port=""
+if [[ "$ssh_enabled" == "true" && -n "${SUPERVISOR_TOKEN:-}" ]]; then
+  if ! ssh_host_port="$(
+    curl \
+      --fail \
+      --silent \
+      --max-time 10 \
+      --header "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+      http://supervisor/addons/self/info 2>/dev/null \
+      | jq -r '.data.network["22/tcp"] // empty'
+  )"; then
+    ssh_host_port=""
+  fi
+fi
 case "$codex_update_timeout" in
   *[!0-9]*|'') codex_update_timeout=300 ;;
 esac
@@ -202,6 +217,148 @@ if [[ "$theme" == "dark" ]]; then
   colors='background=#1e1e2e,foreground=#cdd6f4,cursor=#f5e0dc'
 else
   colors='background=#eff1f5,foreground=#4c4f69,cursor=#dc8a78'
+fi
+
+if [[ "$ssh_enabled" == "true" ]]; then
+  chown 0:0 /data/options.json
+  chmod 600 /data/options.json
+
+  session_options_tmp="$(mktemp "$CODEX_MANAGED_ROOT/.session-options.XXXXXX")"
+  jq '{
+    working_directory: (.working_directory // "/homeassistant"),
+    default_model: (.default_model // ""),
+    enable_mcp: .enable_mcp,
+    codex_permissions: (.codex_permissions // "workspace"),
+    codex_approval_policy: (.codex_approval_policy // "on-request")
+  }' /data/options.json > "$session_options_tmp"
+  chmod 644 "$session_options_tmp"
+  mv -f "$session_options_tmp" "$CODEX_MANAGED_ROOT/session-options.json"
+
+  ssh_user_root="$CODEX_STATE_ROOT/users/anonymous"
+  ssh_user_codex_home="$ssh_user_root/.codex"
+  ssh_user_npm_cache="$ssh_user_root/.npm"
+  ssh_user_npm_prefix="$ssh_user_root/.local"
+  ssh_user_npm_bin="$ssh_user_npm_prefix/bin"
+  ssh_authorized_keys_dir="$ssh_user_root/.ssh"
+  ssh_state_root="/data/ssh"
+
+  if [[ -L "$ssh_authorized_keys_dir" ]]; then
+    echo "[ERROR] Refusing to use a symbolic link as the SSH authorized-keys directory" >&2
+    exit 1
+  fi
+
+  mkdir -p \
+    "$ssh_user_codex_home" \
+    "$ssh_user_npm_cache" \
+    "$ssh_user_npm_bin" \
+    "$ssh_authorized_keys_dir" \
+    "$ssh_state_root" \
+    /run/sshd
+
+  chown -R 22000:0 "$ssh_user_root"
+  chmod 700 \
+    "$ssh_user_root" \
+    "$ssh_user_codex_home" \
+    "$ssh_user_npm_cache" \
+    "$ssh_user_npm_prefix" \
+    "$ssh_authorized_keys_dir"
+  chmod 755 "$ssh_user_npm_bin"
+  chown 0:0 "$ssh_state_root"
+  chmod 700 "$ssh_state_root"
+
+  rm -f "$ssh_user_codex_home/AGENTS.md"
+  if [[ -f "$CODEX_MANAGED_ROOT/AGENTS.md" ]]; then
+    ln -sfn "$CODEX_MANAGED_ROOT/AGENTS.md" "$ssh_user_codex_home/AGENTS.md"
+    chown -h 22000:0 "$ssh_user_codex_home/AGENTS.md"
+  fi
+
+  /usr/local/bin/codex-merge-config \
+    "$ssh_user_codex_home/config.toml" \
+    "$default_model" \
+    "$enable_mcp" \
+    "$codex_permissions" \
+    "$codex_approval_policy" \
+    "$CODEX_MCP_CONFIG"
+  chown 22000:0 "$ssh_user_codex_home/config.toml"
+
+  authorized_keys_tmp="$(mktemp "$ssh_authorized_keys_dir/.authorized_keys.XXXXXX")"
+  while IFS= read -r authorized_key; do
+    if [[ -z "$authorized_key" ]]; then
+      continue
+    fi
+    if [[ "$authorized_key" == *$'\r'* ]]; then
+      echo "[ERROR] SSH authorized keys must not contain carriage returns" >&2
+      rm -f "$authorized_keys_tmp"
+      exit 1
+    fi
+
+    read -r authorized_key_type authorized_key_blob _ <<< "$authorized_key"
+    case "$authorized_key_type" in
+      ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|sk-ecdsa-sha2-nistp256@openssh.com|sk-ssh-ed25519@openssh.com) ;;
+      *)
+        echo "[ERROR] Unsupported or malformed SSH public key type" >&2
+        rm -f "$authorized_keys_tmp"
+        exit 1
+        ;;
+    esac
+    if [[ ! "$authorized_key_blob" =~ ^[A-Za-z0-9+/]+={0,3}$ ]]; then
+      echo "[ERROR] Malformed SSH public key data" >&2
+      rm -f "$authorized_keys_tmp"
+      exit 1
+    fi
+    printf '%s\n' "$authorized_key" >> "$authorized_keys_tmp"
+  done < <(jq -r '.authorized_keys // [] | .[]' /data/options.json)
+  chown 22000:0 "$authorized_keys_tmp"
+  chmod 600 "$authorized_keys_tmp"
+  mv -f "$authorized_keys_tmp" "$ssh_authorized_keys_dir/authorized_keys"
+
+  if ! jq -e '(.ssh_password // "") | (type == "string") and ((contains("\n") or contains("\r")) | not)' /data/options.json >/dev/null; then
+    echo "[ERROR] SSH password must be a single-line string" >&2
+    exit 1
+  fi
+  ssh_password="$(jq -r '.ssh_password // ""' /data/options.json)"
+  if [[ -n "$ssh_password" ]]; then
+    if ! printf '%s:%s\n' codex "$ssh_password" | chpasswd >/dev/null 2>&1; then
+      echo "[ERROR] Unable to set the SSH password for user codex" >&2
+      exit 1
+    fi
+  else
+    passwd -d codex >/dev/null
+  fi
+  unset ssh_password
+
+  generate_ssh_host_key() {
+    local key_type="$1"
+    local key_path="$2"
+    shift 2
+    if [[ ! -s "$key_path" ]]; then
+      ssh-keygen -q -t "$key_type" "$@" -N '' -f "$key_path"
+    fi
+  }
+
+  generate_ssh_host_key ed25519 "$ssh_state_root/ssh_host_ed25519_key"
+  generate_ssh_host_key rsa "$ssh_state_root/ssh_host_rsa_key" -b 3072
+  chown 0:0 \
+    "$ssh_state_root/ssh_host_ed25519_key" \
+    "$ssh_state_root/ssh_host_ed25519_key.pub" \
+    "$ssh_state_root/ssh_host_rsa_key" \
+    "$ssh_state_root/ssh_host_rsa_key.pub"
+  chmod 600 \
+    "$ssh_state_root/ssh_host_ed25519_key" \
+    "$ssh_state_root/ssh_host_rsa_key"
+  chmod 644 \
+    "$ssh_state_root/ssh_host_ed25519_key.pub" \
+    "$ssh_state_root/ssh_host_rsa_key.pub"
+
+  /usr/sbin/sshd -t -f /etc/ssh/sshd_config
+  /usr/sbin/sshd -f /etc/ssh/sshd_config
+  if [[ "$ssh_host_port" =~ ^[0-9]+$ ]]; then
+    echo "[INFO] SSH server started for user codex on host port ${ssh_host_port} (mapped to container port 22)"
+  else
+    echo "[INFO] SSH server started for user codex on container port 22; no host port mapping detected"
+  fi
+else
+  echo "[INFO] SSH server disabled"
 fi
 
 exec ttyd \

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -35,6 +35,8 @@ export CODEX_PERMISSIONS="$codex_permissions"
 export CODEX_APPROVAL_POLICY="$codex_approval_policy"
 export CODEX_HA_URL="http://supervisor/core"
 export CODEX_SUPERVISOR_TOKEN_FILE="/tmp/codex/ha-token"
+export CODEX_MCP_CONFIG="$CODEX_MANAGED_ROOT/mcp-servers.json"
+export CODEX_MCP_ENVIRONMENT="$CODEX_MANAGED_ROOT/mcp-environment.json"
 
 mkdir -p \
   "$CODEX_STATE_ROOT/users" \
@@ -42,6 +44,15 @@ mkdir -p \
   /tmp/codex
 
 chmod 700 /tmp/codex
+
+/usr/local/bin/codex-prepare-mcp \
+  /data/options.json \
+  "$CODEX_MCP_CONFIG" \
+  "$CODEX_MCP_ENVIRONMENT"
+chown 0:0 "$CODEX_MCP_CONFIG"
+chown 22000:0 "$CODEX_MCP_ENVIRONMENT"
+chmod 644 "$CODEX_MCP_CONFIG"
+chmod 600 "$CODEX_MCP_ENVIRONMENT"
 
 if [[ -d /homeassistant/.codex-home && ! -d "$CODEX_STATE_ROOT/legacy-global-home" ]]; then
   cp -a /homeassistant/.codex-home "$CODEX_STATE_ROOT/legacy-global-home"
@@ -125,6 +136,8 @@ When users mention `/config/...`, translate to `/homeassistant/...`
 
 Use the `homeassistant` MCP server to query entities and call services when MCP is enabled. The Supervisor token stays outside the interactive shell and is only available through the privileged `hass-mcp` helper path.
 
+Additional remote MCP servers configured in the App options are also managed in `~/.codex/config.toml`. Their bearer tokens and any additional configured environment variables are supplied to the Codex process environment.
+
 ## Reading Home Assistant Logs
 
 **Log levels (from most to least verbose):**
@@ -163,7 +176,13 @@ validate_home="$CODEX_MANAGED_ROOT/validate-home"
 rm -rf "$validate_home"
 mkdir -p "$validate_home"
 trap 'rm -rf "$validate_home"' EXIT
-/usr/local/bin/codex-merge-config "${validate_home}/config.toml" "$default_model" "$enable_mcp" "$codex_permissions" "$codex_approval_policy"
+/usr/local/bin/codex-merge-config \
+  "${validate_home}/config.toml" \
+  "$default_model" \
+  "$enable_mcp" \
+  "$codex_permissions" \
+  "$codex_approval_policy" \
+  "$CODEX_MCP_CONFIG"
 if CODEX_HOME="$validate_home" codex debug prompt-input --help >/dev/null 2>&1; then
   CODEX_HOME="$validate_home" codex debug prompt-input "startup validation" >/dev/null
 else

--- a/codex/rootfs/usr/local/bin/codex-start
+++ b/codex/rootfs/usr/local/bin/codex-start
@@ -12,7 +12,7 @@ fi
 theme="$(jq -r '.terminal_theme // "dark"' /data/options.json)"
 session_persist="$(jq -r '.session_persistence // false' /data/options.json)"
 work_dir="$(jq -r '.working_directory // "/homeassistant"' /data/options.json)"
-enable_mcp="$(jq -r '.enable_mcp // true' /data/options.json)"
+enable_mcp="$(jq -r '.enable_mcp' /data/options.json)"
 default_model="$(jq -r '.default_model // ""' /data/options.json)"
 codex_permissions="$(jq -r '.codex_permissions // "workspace"' /data/options.json)"
 codex_approval_policy="$(jq -r '.codex_approval_policy // "on-request"' /data/options.json)"
@@ -171,10 +171,10 @@ else
 fi
 if [[ "$enable_mcp" == "true" ]]; then
   CODEX_HOME="$validate_home" codex mcp get homeassistant >/dev/null
-  echo "[INFO] Home Assistant MCP configured for Codex home"
+  echo '[INFO] Bundled MCP server registered: "homeassistant" (voska/hass-mcp)'
 else
   CODEX_HOME="$validate_home" codex mcp list >/dev/null
-  echo "[INFO] Home Assistant MCP disabled"
+  echo '[INFO] Bundled MCP server disabled: "homeassistant"'
 fi
 rm -rf "$validate_home"
 trap - EXIT
@@ -186,6 +186,7 @@ else
 fi
 
 exec ttyd \
+  --debug 3 \
   --port 7681 \
   --writable \
   --ping-interval 30 \

--- a/codex/tests/test_bundled_mcp_option.py
+++ b/codex/tests/test_bundled_mcp_option.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+START_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-start"
+MERGE_CONFIG = CODEX_DIR / "rootfs/usr/local/bin/codex-merge-config"
+
+
+class BundledMcpOptionTests(unittest.TestCase):
+    def test_explicit_false_is_not_replaced_by_default(self):
+        start_text = START_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotIn(".enable_mcp // true", start_text)
+        result = subprocess.run(
+            ["jq", "-r", ".enable_mcp"],
+            input=json.dumps({"enable_mcp": False}),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "false")
+
+    def test_disabling_bundled_mcp_removes_managed_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "config.toml"
+
+            enabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "true", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(enabled.returncode, 0, enabled.stderr)
+            self.assertIn(
+                "homeassistant",
+                tomllib.loads(config_path.read_text(encoding="utf-8"))["mcp_servers"],
+            )
+
+            disabled = subprocess.run(
+                [sys.executable, MERGE_CONFIG, config_path, "", "false", "workspace", "on-request"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(disabled.returncode, 0, disabled.stderr)
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("mcp_servers", config)
+            self.assertNotIn(
+                "managed_homeassistant_mcp",
+                config.get("__homeassistant_app", {}),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/tests/test_mcp_config.py
+++ b/codex/tests/test_mcp_config.py
@@ -1,0 +1,163 @@
+import json
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+PREPARE_MCP = CODEX_DIR / "rootfs/usr/local/bin/codex-prepare-mcp"
+MERGE_CONFIG = CODEX_DIR / "rootfs/usr/local/bin/codex-merge-config"
+
+
+class McpOptionsTests(unittest.TestCase):
+    def run_prepare(self, directory, options):
+        options_path = directory / "options.json"
+        servers_path = directory / "servers.json"
+        environment_path = directory / "environment.json"
+        options_path.write_text(json.dumps(options), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, PREPARE_MCP, options_path, servers_path, environment_path],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, servers_path, environment_path
+
+    def test_prepares_remote_server_and_automatic_bearer_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            result, servers_path, environment_path = self.run_prepare(
+                directory,
+                {
+                    "mcp_servers": [
+                        {
+                            "name": "example-cloud",
+                            "url": "https://mcp.example.com/mcp",
+                            "bearer_token": "secret-token",
+                        }
+                    ],
+                    "environment_variables": [{"name": "EXAMPLE_TENANT", "value": "home"}],
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(servers_path.read_text(encoding="utf-8")),
+                [
+                    {
+                        "name": "example-cloud",
+                        "url": "https://mcp.example.com/mcp",
+                        "bearer_token_env_var": "CODEX_MCP_EXAMPLE_CLOUD_BEARER_TOKEN",
+                    }
+                ],
+            )
+            self.assertEqual(
+                json.loads(environment_path.read_text(encoding="utf-8")),
+                [
+                    {"name": "EXAMPLE_TENANT", "value": "home"},
+                    {"name": "CODEX_MCP_EXAMPLE_CLOUD_BEARER_TOKEN", "value": "secret-token"},
+                ],
+            )
+            self.assertEqual(environment_path.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn("secret-token", servers_path.read_text(encoding="utf-8"))
+
+    def test_rejects_environment_collision_with_generated_bearer_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            result, _, _ = self.run_prepare(
+                directory,
+                {
+                    "mcp_servers": [
+                        {"name": "example", "url": "https://example.com/mcp", "bearer_token": "secret"}
+                    ],
+                    "environment_variables": [
+                        {"name": "CODEX_MCP_EXAMPLE_BEARER_TOKEN", "value": "other"}
+                    ],
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("conflicts", result.stderr)
+
+
+class McpMergeTests(unittest.TestCase):
+    def run_merge(self, config_path, servers_path):
+        return subprocess.run(
+            [
+                sys.executable,
+                MERGE_CONFIG,
+                config_path,
+                "",
+                "true",
+                "workspace",
+                "on-request",
+                servers_path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_adds_managed_server_without_secret_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            config_path = directory / "config.toml"
+            servers_path = directory / "servers.json"
+            servers_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "example",
+                            "url": "https://example.com/mcp",
+                            "bearer_token_env_var": "CODEX_MCP_EXAMPLE_BEARER_TOKEN",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_merge(config_path, servers_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            config_text = config_path.read_text(encoding="utf-8")
+            config = tomllib.loads(config_text)
+            self.assertEqual(config["mcp_servers"]["example"]["url"], "https://example.com/mcp")
+            self.assertEqual(
+                config["mcp_servers"]["example"]["bearer_token_env_var"],
+                "CODEX_MCP_EXAMPLE_BEARER_TOKEN",
+            )
+            self.assertNotIn("secret", config_text)
+
+    def test_restores_preexisting_same_name_server_when_management_is_removed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            config_path = directory / "config.toml"
+            servers_path = directory / "servers.json"
+            config_path.write_text(
+                '[mcp_servers.example]\ncommand = "original-command"\nargs = ["serve"]\n',
+                encoding="utf-8",
+            )
+            servers_path.write_text(
+                json.dumps([{"name": "example", "url": "https://example.com/mcp"}]),
+                encoding="utf-8",
+            )
+
+            first_result = self.run_merge(config_path, servers_path)
+            self.assertEqual(first_result.returncode, 0, first_result.stderr)
+            managed_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("command", managed_config["mcp_servers"]["example"])
+
+            servers_path.write_text("[]\n", encoding="utf-8")
+            second_result = self.run_merge(config_path, servers_path)
+
+            self.assertEqual(second_result.returncode, 0, second_result.stderr)
+            restored_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(restored_config["mcp_servers"]["example"]["command"], "original-command")
+            self.assertEqual(restored_config["mcp_servers"]["example"]["args"], ["serve"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/tests/test_ssh_config.py
+++ b/codex/tests/test_ssh_config.py
@@ -1,0 +1,65 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+CODEX_DIR = Path(__file__).resolve().parents[1]
+CONFIG = CODEX_DIR / "config.yaml"
+DOCKERFILE = CODEX_DIR / "Dockerfile"
+APPARMOR = CODEX_DIR / "apparmor.txt"
+SSHD_CONFIG = CODEX_DIR / "rootfs/etc/ssh/sshd_config"
+PROFILE = CODEX_DIR / "rootfs/etc/profile.d/codex.sh"
+START_SCRIPT = CODEX_DIR / "rootfs/usr/local/bin/codex-start"
+
+
+class SshConfigurationTests(unittest.TestCase):
+    def test_app_exposes_disabled_by_default_ssh_options(self):
+        config = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+
+        self.assertIsNone(config["ports"]["22/tcp"])
+        self.assertFalse(config["options"]["ssh_enabled"])
+        self.assertEqual(config["options"]["ssh_password"], "")
+        self.assertEqual(config["options"]["authorized_keys"], [])
+        self.assertEqual(config["schema"]["ssh_password"], "password")
+
+    def test_sshd_is_restricted_to_unprivileged_codex_user(self):
+        sshd = SSHD_CONFIG.read_text(encoding="utf-8")
+
+        for directive in (
+            "PermitRootLogin no",
+            "AllowUsers codex",
+            "PermitEmptyPasswords no",
+            "X11Forwarding no",
+            "AllowAgentForwarding no",
+            "AllowTcpForwarding no",
+            "AllowStreamLocalForwarding no",
+            "DisableForwarding yes",
+            "PermitTunnel no",
+            "PermitUserEnvironment no",
+            "PermitUserRC no",
+        ):
+            self.assertIn(directive, sshd)
+
+    def test_image_and_apparmor_include_only_required_ssh_runtime(self):
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+        apparmor = APPARMOR.read_text(encoding="utf-8")
+
+        self.assertIn("openssh-server", dockerfile)
+        self.assertIn("capability net_bind_service,", apparmor)
+        self.assertIn("capability sys_chroot,", apparmor)
+        self.assertIn("/run/sshd/** rwk,", apparmor)
+
+    def test_ssh_sessions_preserve_mcp_state_and_safe_logging(self):
+        profile = PROFILE.read_text(encoding="utf-8")
+        start = START_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotIn(".enable_mcp // true", profile)
+        self.assertIn('CODEX_MCP_ENVIRONMENT=/data/codex-managed/mcp-environment.json', profile)
+        self.assertIn('.data.network["22/tcp"] // empty', start)
+        self.assertIn("host port ${ssh_host_port} (mapped to container port 22)", start)
+        self.assertIn("chpasswd >/dev/null 2>&1", start)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/translations/en.yaml
+++ b/codex/translations/en.yaml
@@ -53,6 +53,21 @@ configuration:
     description: >-
       Maximum seconds to wait for the optional Codex CLI startup update.
       Applies only when auto-update is enabled.
+  ssh_enabled:
+    name: Enable SSH
+    description: >-
+      Start OpenSSH for the unprivileged codex user. You must also map
+      container port 22 in the Network section before it is reachable.
+  ssh_password:
+    name: SSH Password
+    description: >-
+      Password for the codex SSH user. Leave empty to disable password login.
+      Public-key login can be used at the same time.
+  authorized_keys:
+    name: SSH Authorized Keys
+    description: >-
+      Public keys allowed to log in as codex. Add one complete public key per
+      list entry.
   mcp_servers:
     name: Remote MCP Servers
     description: >-
@@ -74,7 +89,7 @@ configuration:
     description: >-
       Additional environment variables for Codex and its MCP servers. Values
       are treated as secrets in the App options and are available to Codex
-      sessions.
+      terminal and SSH sessions.
     fields:
       name:
         name: Variable Name
@@ -85,3 +100,4 @@ configuration:
 
 network:
   7681/tcp: Web Terminal (ttyd)
+  22/tcp: SSH server (disabled by default)

--- a/codex/translations/en.yaml
+++ b/codex/translations/en.yaml
@@ -53,6 +53,35 @@ configuration:
     description: >-
       Maximum seconds to wait for the optional Codex CLI startup update.
       Applies only when auto-update is enabled.
+  mcp_servers:
+    name: Remote MCP Servers
+    description: >-
+      Streamable HTTP MCP servers to add to Codex. For each non-empty bearer
+      token, the App automatically creates a protected environment variable
+      and configures bearer_token_env_var for that server.
+    fields:
+      name:
+        name: Server Name
+        description: Unique Codex MCP server name. The name homeassistant is reserved.
+      url:
+        name: Server URL
+        description: Streamable HTTP MCP endpoint beginning with http:// or https://.
+      bearer_token:
+        name: Bearer Token
+        description: Optional token; the App automatically passes it through an environment variable.
+  environment_variables:
+    name: Environment Variables
+    description: >-
+      Additional environment variables for Codex and its MCP servers. Values
+      are treated as secrets in the App options and are available to Codex
+      sessions.
+    fields:
+      name:
+        name: Variable Name
+        description: Environment variable name using letters, digits, and underscores.
+      value:
+        name: Variable Value
+        description: Value made available to Codex and its MCP servers.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/codex/translations/es.yaml
+++ b/codex/translations/es.yaml
@@ -56,6 +56,21 @@ configuration:
     description: >-
       Segundos máximos para esperar la actualización opcional de Codex CLI al
       iniciar. Solo aplica cuando la actualización automática está habilitada.
+  ssh_enabled:
+    name: Habilitar SSH
+    description: >-
+      Inicia OpenSSH para el usuario codex sin privilegios. También debes
+      mapear el puerto 22 del contenedor en la sección Red.
+  ssh_password:
+    name: Contraseña SSH
+    description: >-
+      Contraseña del usuario SSH codex. Déjala vacía para deshabilitar el
+      acceso por contraseña. El acceso con clave pública puede usarse a la vez.
+  authorized_keys:
+    name: Claves SSH autorizadas
+    description: >-
+      Claves públicas autorizadas para iniciar sesión como codex. Añade una
+      clave pública completa por elemento de la lista.
   mcp_servers:
     name: Servidores MCP remotos
     description: >-
@@ -76,7 +91,8 @@ configuration:
     name: Variables de entorno
     description: >-
       Variables de entorno adicionales para Codex y sus servidores MCP. Los
-      valores se tratan como secretos y están disponibles en sesiones de Codex.
+      valores se tratan como secretos y están disponibles en sesiones de
+      terminal y SSH de Codex.
     fields:
       name:
         name: Nombre de la variable
@@ -87,3 +103,4 @@ configuration:
 
 network:
   7681/tcp: Terminal Web (ttyd)
+  22/tcp: Servidor SSH (deshabilitado por defecto)

--- a/codex/translations/es.yaml
+++ b/codex/translations/es.yaml
@@ -56,6 +56,34 @@ configuration:
     description: >-
       Segundos máximos para esperar la actualización opcional de Codex CLI al
       iniciar. Solo aplica cuando la actualización automática está habilitada.
+  mcp_servers:
+    name: Servidores MCP remotos
+    description: >-
+      Servidores MCP HTTP Streamable que se añadirán a Codex. Para cada token
+      bearer no vacío, la App crea automáticamente una variable de entorno
+      protegida y configura bearer_token_env_var para ese servidor.
+    fields:
+      name:
+        name: Nombre del servidor
+        description: Nombre único del servidor MCP de Codex. homeassistant está reservado.
+      url:
+        name: URL del servidor
+        description: Endpoint MCP HTTP Streamable que comienza con http:// o https://.
+      bearer_token:
+        name: Token bearer
+        description: Token opcional que la App pasa automáticamente mediante una variable de entorno.
+  environment_variables:
+    name: Variables de entorno
+    description: >-
+      Variables de entorno adicionales para Codex y sus servidores MCP. Los
+      valores se tratan como secretos y están disponibles en sesiones de Codex.
+    fields:
+      name:
+        name: Nombre de la variable
+        description: Nombre de variable de entorno con letras, números y guiones bajos.
+      value:
+        name: Valor de la variable
+        description: Valor disponible para Codex y sus servidores MCP.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/codex/translations/pt-BR.yaml
+++ b/codex/translations/pt-BR.yaml
@@ -56,6 +56,34 @@ configuration:
       Segundos máximos para aguardar a atualização opcional do Codex CLI na
       inicialização. Aplica-se apenas quando a atualização automática está
       habilitada.
+  mcp_servers:
+    name: Servidores MCP remotos
+    description: >-
+      Servidores MCP HTTP Streamable que serão adicionados ao Codex. Para cada
+      bearer token não vazio, o App cria automaticamente uma variável de
+      ambiente protegida e configura bearer_token_env_var para o servidor.
+    fields:
+      name:
+        name: Nome do servidor
+        description: Nome exclusivo do servidor MCP do Codex. homeassistant é reservado.
+      url:
+        name: URL do servidor
+        description: Endpoint MCP HTTP Streamable iniciado por http:// ou https://.
+      bearer_token:
+        name: Bearer token
+        description: Token opcional que o App passa automaticamente por uma variável de ambiente.
+  environment_variables:
+    name: Variáveis de ambiente
+    description: >-
+      Variáveis de ambiente adicionais para o Codex e seus servidores MCP. Os
+      valores são tratados como segredos e ficam disponíveis nas sessões do Codex.
+    fields:
+      name:
+        name: Nome da variável
+        description: Nome de variável de ambiente com letras, números e sublinhados.
+      value:
+        name: Valor da variável
+        description: Valor disponibilizado ao Codex e aos servidores MCP.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/codex/translations/pt-BR.yaml
+++ b/codex/translations/pt-BR.yaml
@@ -56,6 +56,21 @@ configuration:
       Segundos máximos para aguardar a atualização opcional do Codex CLI na
       inicialização. Aplica-se apenas quando a atualização automática está
       habilitada.
+  ssh_enabled:
+    name: Habilitar SSH
+    description: >-
+      Inicia o OpenSSH para o usuário codex sem privilégios. Você também deve
+      mapear a porta 22 do contêiner na seção Rede.
+  ssh_password:
+    name: Senha SSH
+    description: >-
+      Senha do usuário SSH codex. Deixe vazia para desabilitar o login por
+      senha. O login por chave pública pode ser usado ao mesmo tempo.
+  authorized_keys:
+    name: Chaves SSH autorizadas
+    description: >-
+      Chaves públicas autorizadas para login como codex. Adicione uma chave
+      pública completa por item da lista.
   mcp_servers:
     name: Servidores MCP remotos
     description: >-
@@ -76,7 +91,8 @@ configuration:
     name: Variáveis de ambiente
     description: >-
       Variáveis de ambiente adicionais para o Codex e seus servidores MCP. Os
-      valores são tratados como segredos e ficam disponíveis nas sessões do Codex.
+      valores são tratados como segredos e ficam disponíveis nas sessões de
+      terminal e SSH do Codex.
     fields:
       name:
         name: Nome da variável
@@ -87,3 +103,4 @@ configuration:
 
 network:
   7681/tcp: Terminal Web (ttyd)
+  22/tcp: Servidor SSH (desabilitado por padrão)


### PR DESCRIPTION
## Summary

- add optional, disabled-by-default OpenSSH access for the existing unprivileged `codex` user
- support password and public-key authentication with persistent host keys under `/data/ssh`
- restrict sshd to the `codex` user and disable forwarding, tunneling, root login, and empty passwords
- preserve the same Codex home, managed MCP environment, and working directory for SSH sessions
- report the effective Supervisor host-port mapping without logging credentials
- add AppArmor rules, options, translations, documentation, and regression tests

## Testing

- `python3 -B -m unittest discover -s codex/tests -v`
- `bash -n codex/rootfs/usr/local/bin/codex-start codex/rootfs/usr/local/bin/codex-shell`
- parsed App, repository, and translation YAML
- `git diff --check`
- built the amd64 container image
- container smoke check generated persistent-style host keys and passed `sshd -t` with the bundled configuration

## Dependency

Depends on #6 and #9. SSH sessions reuse the managed session/environment setup introduced by #9.

This is intentionally a stacked draft. Once its dependencies merge, the branch can be rebased onto `main` so the PR shows only the SSH change.
